### PR TITLE
로그 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,4 +73,4 @@ jobs:
             done
             docker image prune -a -f
             docker pull ${{ secrets.ECR_REGISTRY }}/keyme-api-server-ecr:latest
-            docker run -d --log-driver=syslog -p 80:8080 ${{ secrets.ECR_REGISTRY }}/keyme-api-server-ecr:latest
+            docker run -d --log-driver=syslog -v /keyme-logs:/logs -p 80:8080 ${{ secrets.ECR_REGISTRY }}/keyme-api-server-ecr:latest

--- a/src/main/resources/logback-console-appender.xml
+++ b/src/main/resources/logback-console-appender.xml
@@ -1,0 +1,9 @@
+<included>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %msg %n
+            </pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-file-error-appender.xml
+++ b/src/main/resources/logback-file-error-appender.xml
@@ -1,0 +1,25 @@
+<included>
+    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>error</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>
+                ./log/ERROR/keyme-error-%d{yyyy-MM-dd}_%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>
+                %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %C %M %n %msg %n%n
+            </pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-file-error-appender.xml
+++ b/src/main/resources/logback-file-error-appender.xml
@@ -1,25 +1,25 @@
 <included>
-    <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <filter class="ch.qos.logback.classic.filter.LevelFilter">
-            <level>error</level>
-            <onMatch>ACCEPT</onMatch>
-            <onMismatch>DENY</onMismatch>
-        </filter>
+        <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>error</level>
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
 
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>
-                ./log/ERROR/keyme-error-%d{yyyy-MM-dd}_%i.log
-            </fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>
+                    /log/ERROR/keyme-error-%d{yyyy-MM-dd}_%i.log
+                </fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>100MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
 
-        <encoder>
-            <pattern>
-                %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %C %M %n %msg %n%n
-            </pattern>
-        </encoder>
-    </appender>
+            <encoder>
+                <pattern>
+                    %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %C %M %n %msg %n%n
+                </pattern>
+            </encoder>
+        </appender>
 </included>

--- a/src/main/resources/logback-file-error-appender.xml
+++ b/src/main/resources/logback-file-error-appender.xml
@@ -11,7 +11,7 @@
                 ./log/ERROR/keyme-error-%d{yyyy-MM-dd}_%i.log
             </fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
+                <maxFileSize>100MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
             <maxHistory>7</maxHistory>
         </rollingPolicy>

--- a/src/main/resources/logback-file-info-appender.xml
+++ b/src/main/resources/logback-file-info-appender.xml
@@ -5,7 +5,7 @@
                 ./log/INFO/keyme-info-%d{yyyy-MM-dd}_%i.log
             </fileNamePattern>
             <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>10MB</maxFileSize>
+                <maxFileSize>100MB</maxFileSize>
             </timeBasedFileNamingAndTriggeringPolicy>
             <maxHistory>7</maxHistory>
         </rollingPolicy>

--- a/src/main/resources/logback-file-info-appender.xml
+++ b/src/main/resources/logback-file-info-appender.xml
@@ -1,0 +1,19 @@
+<included>
+    <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>
+                ./log/INFO/keyme-info-%d{yyyy-MM-dd}_%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>
+                %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %msg %n
+            </pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-file-info-appender.xml
+++ b/src/main/resources/logback-file-info-appender.xml
@@ -1,19 +1,19 @@
 <included>
-    <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>
-                ./log/INFO/keyme-info-%d{yyyy-MM-dd}_%i.log
-            </fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <maxFileSize>100MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <maxHistory>7</maxHistory>
-        </rollingPolicy>
+        <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>
+                    /log/INFO/keyme-info-%d{yyyy-MM-dd}_%i.log
+                </fileNamePattern>
+                <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                    <maxFileSize>100MB</maxFileSize>
+                </timeBasedFileNamingAndTriggeringPolicy>
+                <maxHistory>7</maxHistory>
+            </rollingPolicy>
 
-        <encoder>
-            <pattern>
-                %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %msg %n
-            </pattern>
-        </encoder>
-    </appender>
+            <encoder>
+                <pattern>
+                    %d{yyyy:MM:dd HH:mm:ss.SSS} %-5level --- [%thread] %logger{35} : %msg %n
+                </pattern>
+            </encoder>
+        </appender>
 </included>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,13 +2,23 @@
 <!DOCTYPE configuration>
 
 <configuration>
-    <include resource="logback-console-appender.xml"/>
-    <include resource="logback-file-info-appender.xml"/>
-    <include resource="logback-file-error-appender.xml"/>
+    <springProfile name="prod">
+        <include resource="logback-console-appender.xml"/>
+        <include resource="logback-file-info-appender.xml"/>
+        <include resource="logback-file-error-appender.xml"/>
 
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE_INFO"/>
-        <appender-ref ref="FILE_ERROR"/>
-    </root>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE_INFO"/>
+            <appender-ref ref="FILE_ERROR"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!prod">
+        <include resource="logback-console-appender.xml"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <include resource="logback-console-appender.xml"/>
+    <include resource="logback-file-info-appender.xml"/>
+    <include resource="logback-file-error-appender.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE_INFO"/>
+        <appender-ref ref="FILE_ERROR"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### Summary
- 프로젝트에서 사용되는 로그의 출력 범위 및 출력 위치를 지정하는 설정을 추가했습니다.

### Description
- logback.xml을 통해 logback 관련 설정을 추가했습니다. 아침 논의 이후 yml로 바꾸는 방법을 찾아봤는데, yml에서 지원하지 않는 옵션들이 꽤 있어서(로그 레벨 필터 등) 우선은 xml로 유지해 두었습니다.
- spring profile에 따라 `prod` 프로필일 때에만 `INFO` 및 `ERROR` 레벨 로그를 파일로도 별도 저장하고, 이외 프로필은 콘솔 출력만 하도록 설정했습니다.
- 도커의 volume 기능을 사용해서, 컨테이너 내의 `/logs` 경로와 호스트의 `/keyme-logs` 디렉토리를 연동하도록 하는 옵션을 워크플로우에 추가했습니다(-v 옵션). 로컬에서 테스트해본 바로는 컨테이너 내 경로에 파일이 추가되면 연동되는 호스트 경로에도 해당 파일이 추가됩니다. logback 설정에서 파일 경로는 `/logs`로 변경해둔 상태입니다.
- 현재 파일로 출력되는 로그는 최대 7일까지 보관하고, 일별 로그를 100MB 파일 단위로 분할합니다. 실제 운영 시에는 로그 파일이 너무 커질수도 있고, 여러 상황들이 생길 수 있을 것 같은데 일단은 이 설정처럼 파일에 출력하는 형태로 잡아 두고, 추후 상황에 따라 다른 방식이나 툴을 도입해보면 될 것 같습니다.