### PR TITLE
Swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/nexters/keyme/auth/config/SecurityConfig.java
+++ b/src/main/java/com/nexters/keyme/auth/config/SecurityConfig.java
@@ -6,12 +6,10 @@ import com.nexters.keyme.auth.util.AuthenticationTokenProvider;
 import com.nexters.keyme.auth.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -39,7 +37,19 @@ public class SecurityConfig {
             .authenticationEntryPoint(new RestAuthenticationEntryPoint());
 
     http.authorizeRequests()
-            .antMatchers("/hello", "/members")
+            .antMatchers(
+                    "/hello",
+                    "/members",
+                    "/v2/api-docs",
+                    "/swagger-resources",
+                    "/swagger-resources/**",
+                    "/configuration/ui",
+                    "/configuration/security",
+                    "/swagger-ui.html",
+                    "/webjars/**",
+                    /* swagger v3 */
+                    "/v3/api-docs/**",
+                    "/swagger-ui/**")
             .permitAll()
             .anyRequest()
             .authenticated();

--- a/src/main/java/com/nexters/keyme/common/config/SwaggerConfig.java
+++ b/src/main/java/com/nexters/keyme/common/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.nexters.keyme.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import springfox.documentation.builders.PathSelectors;
@@ -20,7 +21,7 @@ public class SwaggerConfig extends WebMvcConfigurationSupport {
         return new Docket(DocumentationType.SWAGGER_2)
                 .useDefaultResponseMessages(true)
                 .select()
-                .apis(RequestHandlerSelectors.any())
+                .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
                 .paths(PathSelectors.any())
                 .build();
     }

--- a/src/main/java/com/nexters/keyme/common/config/SwaggerConfig.java
+++ b/src/main/java/com/nexters/keyme/common/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.nexters.keyme.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig extends WebMvcConfigurationSupport {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .useDefaultResponseMessages(true)
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+
+    @Override
+    protected void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/swagger-ui/**").addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/");
+        registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/");
+    }
+}

--- a/src/main/java/com/nexters/keyme/common/config/SwaggerConfig.java
+++ b/src/main/java/com/nexters/keyme/common/config/SwaggerConfig.java
@@ -5,12 +5,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
-
 
 @Configuration
 @EnableSwagger2
@@ -23,13 +24,20 @@ public class SwaggerConfig extends WebMvcConfigurationSupport {
                 .select()
                 .apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
                 .paths(PathSelectors.any())
-                .build();
+                .build()
+                .apiInfo(apiInfo());
     }
-
 
     @Override
     protected void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/swagger-ui/**").addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/");
         registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/");
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("Keyme API")
+                .description("현재는 기본 요청을 테스트할 수 있는 dummy controller와 로그인 테스트를 할 수 있는 member controller만 구현되어 있습니다.\n JSON 형태로 요청을 받는 경우 parameter 예시값 위의 Model을 누르면 세부 필드 정보를 볼 수 있습니다.\n\n세부 명세는 추후 변경될 수 있습니다.")
+                .build();
     }
 }

--- a/src/main/java/com/nexters/keyme/common/config/WebConfig.java
+++ b/src/main/java/com/nexters/keyme/common/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.nexters.keyme.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/swagger-ui/**")
+                .addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/")
+                .resourceChain(false);
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/swagger-ui/")
+                .setViewName("forward:/swagger-ui/index.html");
+    }
+
+}

--- a/src/main/java/com/nexters/keyme/dummy/DummyController.java
+++ b/src/main/java/com/nexters/keyme/dummy/DummyController.java
@@ -19,10 +19,4 @@ public class DummyController {
     public String helloAuthKeyme() {
         return "Hello Authenticated keyme!";
     }
-  
-    @GetMapping("/notification")
-    public String sendNotification() {
-        dummyService.doLogicAndPublishNotification();
-        return "requested notification";
-    }
 }

--- a/src/main/java/com/nexters/keyme/dummy/DummyController.java
+++ b/src/main/java/com/nexters/keyme/dummy/DummyController.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.dummy;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,11 +12,13 @@ public class DummyController {
     private final DummyService dummyService;
 
     @GetMapping("/hello")
+    @ApiOperation(value = "테스트용 컨트롤러(인증 불필요)", notes = "인증처리 없이 접근할 수 있는 엔드포인트")
     public String helloKeyme() {
         return "Hello keyme!";
     }
 
     @GetMapping("/auth")
+    @ApiOperation(value = "테스트용 컨트롤러(인증 필요)", notes = "인증 처리가 완료되어야 접근 가능한 엔드포인트")
     public String helloAuthKeyme() {
         return "Hello Authenticated keyme!";
     }

--- a/src/main/java/com/nexters/keyme/member/controller/MemberController.java
+++ b/src/main/java/com/nexters/keyme/member/controller/MemberController.java
@@ -3,22 +3,21 @@ package com.nexters.keyme.member.controller;
 import com.nexters.keyme.member.dto.request.LoginRequestDto;
 import com.nexters.keyme.member.dto.response.MemberResponseDto;
 import com.nexters.keyme.member.service.MemberService;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
-
 @RestController
 @RequestMapping("/members")
 @RequiredArgsConstructor
+
 public class MemberController {
   private final MemberService memberService;
-  @PostMapping
+  @PostMapping("/login")
+  @ApiOperation(value = "oauth 로그인", notes = "SDK에서 받은 access token(카카오)/identity token(애플)을 통해 로그인한다.")
   public MemberResponseDto signIn(
           @RequestBody LoginRequestDto request) {
     return memberService.getOrCreateMember(request);

--- a/src/main/java/com/nexters/keyme/member/dto/request/LoginRequestDto.java
+++ b/src/main/java/com/nexters/keyme/member/dto/request/LoginRequestDto.java
@@ -1,19 +1,21 @@
 package com.nexters.keyme.member.dto.request;
 
 import com.nexters.keyme.common.enums.OAuthType;
-import lombok.AllArgsConstructor;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+@ApiModel
 @Getter
 public class LoginRequestDto {
 
+  @ApiModelProperty(value = "Oauth 타입(KAKAO/APPLE)", example = "KAKAO", required = true)
   @NotNull(message = "유효하지 않는 OAuth 타입")
   private OAuthType oauthType;
 
+  @ApiModelProperty(value = "Oauth SDK를 통해 받은 access token(kakao)/identity token(apple)", example = "(token value)", required = true)
   @NotNull
   private String token;
 }

--- a/src/main/java/com/nexters/keyme/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/nexters/keyme/member/dto/response/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.member.dto.response;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,8 +11,10 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 @Builder
 public class MemberResponseDto {
+  @ApiModelProperty(value="유저 id", example = "7")
   @NotNull
   private Long id;
+
 
   private TokenResponseDto token;
 }

--- a/src/main/java/com/nexters/keyme/member/dto/response/TokenResponseDto.java
+++ b/src/main/java/com/nexters/keyme/member/dto/response/TokenResponseDto.java
@@ -1,11 +1,14 @@
 package com.nexters.keyme.member.dto.response;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class TokenResponseDto {
+  @ApiModelProperty(value="Access JWT 토큰")
   private String accessToken;
+  @ApiModelProperty(value="Refresh JWT 토큰")
   private String refreshToken;
 }


### PR DESCRIPTION
### Summary
- API 명세 공유 및 테스트를 위한 Swagger 설정을 추가했습니다.

### Description
- 설정 과정에서 Spring Security로 인해 접근이 안 되는 문제가 있었습니다. 실제 API 페이지 경로 외에도 Swagger가 내부적으로 사용하는 경로들에 대한 접근 권한이 필요해서 생겼던 문제로 보입니다. 관련 내용은 이 [링크](https://devfunny.tistory.com/692)를 참조했습니다.
- `/swagger-ui/index.html` 경로를 통해 접속 가능합니다.
- 현재는 `DummyController`를 통한 기본 요청과 `MemberController`를 통한 로그인 요청만 테스트할 수 있도록 작성했습니다.