### PR TITLE
ApiResponse statusCode state로 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/common/dto/response/ApiResponse.java
+++ b/src/main/java/com/nexters/keyme/common/dto/response/ApiResponse.java
@@ -2,31 +2,26 @@ package com.nexters.keyme.common.dto.response;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public class ApiResponse<T> {
     @ApiModelProperty(value="HTTP 상태코드", example = "200")
-    private int statusCode;
+    private String state;
     @ApiModelProperty(value="메시지", example = "SUCCESS")
     private String message;
     private T data;
 
-    public ApiResponse(int statusCode, String message, T data) {
-        this.statusCode = statusCode;
+
+    public ApiResponse(String status, String message, T data) {
+        this.state = status;
         this.message = message;
         this.data = data;
     }
 
-    public ApiResponse(HttpStatus status, String message, T data) {
-        this.statusCode = status.value();
-        this.message = message;
+    public ApiResponse(T data) {
+        this.state = "SUCCESS";
+        this.message = "요청에 성공했습니다.";
         this.data = data;
     }
 
-    public ApiResponse(HttpStatus status, T data) {
-        this.statusCode = status.value();
-        this.message = status.getReasonPhrase();
-        this.data = data;
-    }
 }

--- a/src/main/java/com/nexters/keyme/friend/presentation/controller/FriendController.java
+++ b/src/main/java/com/nexters/keyme/friend/presentation/controller/FriendController.java
@@ -10,7 +10,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,20 +37,20 @@ public class FriendController {
                 .thumbnailUrl("thumbnail url")
                 .build();
 
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", List.of(response)));
+        return ResponseEntity.ok(new ApiResponse<>(List.of(response)));
     }
 
     @PostMapping("/request")
     @ApiOperation(value = "친구 추가 요청 보내기")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse> addFriend(FriendAddRequest request) {
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "친구 추가 요청이 완료되었습니다.", null));
+        return ResponseEntity.ok(new ApiResponse<>(null));
     }
 
     @PostMapping("/response")
     @ApiOperation(value = "친구 추가 요청 응답하기")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse> acceptFriend(FriendAcceptRequest request) {
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "친구 추가 요청이 완료되었습니다.", null));
+        return ResponseEntity.ok(new ApiResponse<>(null));
     }
 }

--- a/src/main/java/com/nexters/keyme/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/nexters/keyme/member/presentation/controller/MemberController.java
@@ -6,13 +6,12 @@ import com.nexters.keyme.common.dto.response.ApiResponse;
 import com.nexters.keyme.member.application.MemberService;
 import com.nexters.keyme.member.presentation.dto.request.MemberModificationRequest;
 import com.nexters.keyme.member.presentation.dto.request.NicknameVerificationRequest;
-import com.nexters.keyme.member.presentation.dto.response.NicknameVerificationResponse;
 import com.nexters.keyme.member.presentation.dto.response.MemberResponse;
+import com.nexters.keyme.member.presentation.dto.response.NicknameVerificationResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,14 +29,14 @@ public class MemberController {
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse<MemberResponse>> getMemberInfo(@PathVariable(name = "memberId") Long memberId) {
         MemberResponse response = memberService.getMemberInfo(memberId);
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 
     @GetMapping("/verify-nickname")
     @ApiOperation("닉네임 중복 확인")
     public ResponseEntity<ApiResponse<NicknameVerificationResponse>> verifyNickname(NicknameVerificationRequest request) {
         NicknameVerificationResponse response = memberService.verifyNickname(request);
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 
     @PatchMapping
@@ -45,6 +44,6 @@ public class MemberController {
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse<MemberResponse>> verifyNickname(MemberModificationRequest request, @RequestUser UserInfo userInfo) {
         MemberResponse response = memberService.modifyMemberInfo(request, userInfo);
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 }

--- a/src/main/java/com/nexters/keyme/member/presentation/controller/ProfileImageController.java
+++ b/src/main/java/com/nexters/keyme/member/presentation/controller/ProfileImageController.java
@@ -6,9 +6,11 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import static com.nexters.keyme.common.config.SwaggerConfig.SWAGGER_AUTHORIZATION_SCHEME;
@@ -25,6 +27,6 @@ public class ProfileImageController {
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse<ImageResponse>> uploadImage(@RequestPart MultipartFile image) {
         ImageResponse response = new ImageResponse("original url", "thumbnail url");
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 }

--- a/src/main/java/com/nexters/keyme/notification/presentation/controller/NotificationController.java
+++ b/src/main/java/com/nexters/keyme/notification/presentation/controller/NotificationController.java
@@ -6,7 +6,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,6 +35,6 @@ public class NotificationController {
                 .isRead(false)
                 .build();
 
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", List.of(notification)));
+        return ResponseEntity.ok(new ApiResponse<>(List.of(notification)));
     }
 }

--- a/src/main/java/com/nexters/keyme/question/presentation/controller/QuestionController.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/controller/QuestionController.java
@@ -5,7 +5,6 @@ import com.nexters.keyme.question.presentation.dto.response.QuestionResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +22,6 @@ public class QuestionController {
     @ApiOperation(value = "질문 정보 가져오기")
     public ResponseEntity<ApiResponse<QuestionResponse>> questionDetail(@PathVariable("id") Long questinoId) {
         return ResponseEntity
-                .ok(new ApiResponse<QuestionResponse>(HttpStatus.OK, new QuestionResponse()));
+                .ok(new ApiResponse<>(new QuestionResponse()));
     }
 }

--- a/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticsController.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticsController.java
@@ -7,7 +7,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,6 +31,6 @@ public class StatisticsController {
         StatisticResultResponse result = new StatisticResultResponse(question, coordinate);
         MemberStatisticResponse response = new MemberStatisticResponse(14L, List.of(result));
 
-        return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK, "SUCCESS", response));
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 }

--- a/src/main/java/com/nexters/keyme/test/presentation/controller/TestController.java
+++ b/src/main/java/com/nexters/keyme/test/presentation/controller/TestController.java
@@ -12,7 +12,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,7 +31,7 @@ public class TestController {
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse<QuestionsInTestResponse>> getDailyTest(@RequestUser UserInfo requestUser) {
         return ResponseEntity.ok(
-            new ApiResponse<QuestionsInTestResponse>(HttpStatus.OK ,new QuestionsInTestResponse(1L, false, Arrays.asList(
+            new ApiResponse<QuestionsInTestResponse>(new QuestionsInTestResponse(1L, false, Arrays.asList(
                 new QuestionResponse(1L, "공부를 잘 할 것 같다", "공부",  null),
                 new QuestionResponse(2L, "밥을 좋아할 것 같다", "밥",  null),
                 new QuestionResponse(3L, "커피를 사랑할 것 같다", "천재",  null)
@@ -44,7 +43,7 @@ public class TestController {
     @ApiOperation(value = "온보딩 테스트 가져오기")
     public ResponseEntity<ApiResponse<QuestionsInTestResponse>> getOnboardingTest() {
         return ResponseEntity.ok(
-            new ApiResponse<QuestionsInTestResponse>(HttpStatus.OK ,new QuestionsInTestResponse(1L, false, Arrays.asList(
+            new ApiResponse<>(new QuestionsInTestResponse(1L, false, Arrays.asList(
                 new QuestionResponse(1L, "공부를 잘 할 것 같다", "공부",  null),
                 new QuestionResponse(2L, "밥을 좋아할 것 같다", "밥",  null),
                 new QuestionResponse(3L, "커피를 사랑할 것 같다", "천재",  null)
@@ -60,7 +59,7 @@ public class TestController {
         @PathVariable("id") Long testId
     ) {
         return ResponseEntity.ok(
-            new ApiResponse<QuestionsInTestResponse>(HttpStatus.OK, new QuestionsInTestResponse(1L, false, Arrays.asList(
+            new ApiResponse<>(new QuestionsInTestResponse(1L, false, Arrays.asList(
                 new QuestionResponse(1L, "공부를 잘 할 것 같다", "공부",  null),
                 new QuestionResponse(2L, "밥을 좋아할 것 같다", "밥",  null),
                 new QuestionResponse(3L, "커피를 사랑할 것 같다", "천재",  null)
@@ -78,7 +77,7 @@ public class TestController {
         TestListRequest requestParameters
     ) {
         return ResponseEntity.ok(
-            new ApiResponse<List<TestFeedResponse>>(HttpStatus.OK, Arrays.asList( new TestFeedResponse(
+            new ApiResponse<>(Arrays.asList( new TestFeedResponse(
                 1L, 10, "공부를 잘 할 것 같다",
                 new TestSimpleMemberResponse(),
                 new TestResultRateResponse()


### PR DESCRIPTION
### Summary
- 기존 ApiResponse의 statusCode를 문자열인 State로 변경했습니다.

### Description
- 기존 int값이던 statusCode를 String인 state로 변경.
- data 객체만 넣는 생성자(컨트롤러에서 직접 호출)는 state "SUCCESS", message는 "요청에 성공했습니다"로 고정