### PR TITLE
Member State 정의 및 핸들러 추가, 전역 예외처리 수정

### DIFF
--- a/src/main/java/com/nexters/keyme/common/dto/response/ApiResponse.java
+++ b/src/main/java/com/nexters/keyme/common/dto/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.common.dto.response;
 
+import com.nexters.keyme.common.exceptions.errorcode.ErrorCode;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
@@ -22,6 +23,12 @@ public class ApiResponse<T> {
         this.state = "SUCCESS";
         this.message = "요청에 성공했습니다.";
         this.data = data;
+    }
+
+    public ApiResponse(ErrorCode errorCode) {
+        this.state = errorCode.name();
+        this.message = errorCode.message();
+        this.data = null;
     }
 
 }

--- a/src/main/java/com/nexters/keyme/common/exceptions/FileUploadFailedException.java
+++ b/src/main/java/com/nexters/keyme/common/exceptions/FileUploadFailedException.java
@@ -1,0 +1,5 @@
+package com.nexters.keyme.common.exceptions;
+
+public class FileUploadFailedException extends RuntimeException {
+
+}

--- a/src/main/java/com/nexters/keyme/common/exceptions/errorcode/ErrorCode.java
+++ b/src/main/java/com/nexters/keyme/common/exceptions/errorcode/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
 
     ACCESS_DENIED(403, "접근 권한이 없습니다."),
 
-    RESOURCE_NOT_FOUND(404, "대상을 찾을 수 없습니다.");
+    RESOURCE_NOT_FOUND(404, "대상을 찾을 수 없습니다."),
+    FILE_UPLOAD_FAILED(500, "파일 업로드에 실패하였습니다. 재시도해 주세요.");
 
     private final int statusCode;
     private final String message;

--- a/src/main/java/com/nexters/keyme/common/exceptions/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/nexters/keyme/common/exceptions/handler/GlobalExceptionHandler.java
@@ -1,10 +1,11 @@
 package com.nexters.keyme.common.exceptions.handler;
 
-import com.nexters.keyme.common.dto.response.CommonResponse;
+import com.nexters.keyme.common.dto.response.ApiResponse;
 import com.nexters.keyme.common.exceptions.AccessDeniedException;
 import com.nexters.keyme.common.exceptions.AuthorizationFailedException;
 import com.nexters.keyme.common.exceptions.InvalidRequestException;
 import com.nexters.keyme.common.exceptions.ResourceNotFoundException;
+import com.nexters.keyme.common.exceptions.errorcode.ErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -13,22 +14,22 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<CommonResponse> handleAccessDeniedException(AccessDeniedException e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new CommonResponse(HttpStatus.FORBIDDEN.value(), e.getMessage()));
+    public ResponseEntity<ApiResponse> handleAccessDeniedException(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new ApiResponse<>(ErrorCode.ACCESS_DENIED));
     }
 
     @ExceptionHandler(AuthorizationFailedException.class)
-    public ResponseEntity<CommonResponse> handleAuthorizationFailedException(AuthorizationFailedException e) {
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new CommonResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    public ResponseEntity<ApiResponse> handleAuthorizationFailedException(AuthorizationFailedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse(ErrorCode.UNAUTHORIZED.name(), e.getMessage(), null));
     }
 
     @ExceptionHandler(InvalidRequestException.class)
-    public ResponseEntity<CommonResponse> handleInvalidRequestException(InvalidRequestException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new CommonResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
+    public ResponseEntity<ApiResponse> handleInvalidRequestException(InvalidRequestException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ApiResponse<>(ErrorCode.INVALID_REQUEST));
     }
 
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<CommonResponse> handleResourceNotFoundException(ResourceNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new CommonResponse(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+    public ResponseEntity<ApiResponse> handleResourceNotFoundException(ResourceNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ApiResponse(ErrorCode.RESOURCE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/nexters/keyme/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/member/application/MemberServiceImpl.java
@@ -67,6 +67,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public NicknameVerificationResponse verifyNickname(NicknameVerificationRequest request) {
         ValidationInfo validationInfo = nicknameValidator.validateNickname(request.getNickname());
 
@@ -74,12 +75,15 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public MemberResponse modifyMemberInfo(MemberModificationRequest request, UserInfo userInfo) {
         MemberModificationInfo modificationInfo = MemberModificationInfo.builder()
                 .nickname(request.getNickname())
                 .originalImage(request.getProfileImage())
                 .thumbnailImage(request.getProfileThumbnail())
                 .build();
+
+        nicknameValidator.validateNickname(modificationInfo.getNickname());
 
         MemberEntity member = memberRepository.findById(userInfo.getMemberId())
                 .orElseThrow(ResourceNotFoundException::new);

--- a/src/main/java/com/nexters/keyme/member/domain/exceptions/NicknameVerificationException.java
+++ b/src/main/java/com/nexters/keyme/member/domain/exceptions/NicknameVerificationException.java
@@ -1,0 +1,14 @@
+package com.nexters.keyme.member.domain.exceptions;
+
+import com.nexters.keyme.member.domain.state.MemberStateCode;
+import lombok.Getter;
+
+@Getter
+public class NicknameVerificationException extends RuntimeException {
+    private String state;
+
+    public NicknameVerificationException(MemberStateCode stateCode) {
+        super(stateCode.message());
+        this.state = stateCode.name();
+    }
+}

--- a/src/main/java/com/nexters/keyme/member/domain/service/NicknameValidator.java
+++ b/src/main/java/com/nexters/keyme/member/domain/service/NicknameValidator.java
@@ -1,8 +1,10 @@
 package com.nexters.keyme.member.domain.service;
 
+import com.nexters.keyme.member.domain.exceptions.NicknameVerificationException;
 import com.nexters.keyme.member.domain.internaldto.ValidationInfo;
 import com.nexters.keyme.member.domain.model.MemberEntity;
 import com.nexters.keyme.member.domain.repository.MemberRepository;
+import com.nexters.keyme.member.domain.state.MemberStateCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,10 +18,10 @@ public class NicknameValidator {
 
     public ValidationInfo validateNickname(String nickname) {
         if (!isEqualOrLessThanSixChars(nickname)) {
-            return new ValidationInfo(false, "닉네임은 6글자 이하여야 합니다.");
+            throw new NicknameVerificationException(MemberStateCode.NICKNAME_TOO_LONG);
         }
         if (!isUnique(nickname)) {
-            return new ValidationInfo(false, "사용 중인 닉네임입니다.");
+            throw new NicknameVerificationException(MemberStateCode.DUPLICATED_NICKNAME);
         }
 
         return new ValidationInfo(true, "사용 가능한 닉네임입니다");

--- a/src/main/java/com/nexters/keyme/member/domain/state/MemberStateCode.java
+++ b/src/main/java/com/nexters/keyme/member/domain/state/MemberStateCode.java
@@ -1,0 +1,16 @@
+package com.nexters.keyme.member.domain.state;
+
+public enum MemberStateCode {
+    DUPLICATED_NICKNAME("이미 사용 중인 닉네임입니다."),
+    NICKNAME_TOO_LONG("닉네임은 7자 이하여야 합니다.");
+
+    private final String message;
+
+    MemberStateCode(String message) {
+        this.message = message;
+    }
+
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
+++ b/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
@@ -2,6 +2,7 @@ package com.nexters.keyme.member.infrastructure;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.nexters.keyme.common.exceptions.FileUploadFailedException;
 import com.nexters.keyme.member.domain.internaldto.ImageInfo;
 import com.nexters.keyme.member.domain.service.ImageUploader;
 import lombok.RequiredArgsConstructor;
@@ -35,8 +36,8 @@ public class S3ImageUploader implements ImageUploader {
             originalUrl = uploadToS3AndGetUrl(image.getInputStream(), extension);
             thumbnailUrl = uploadToS3AndGetUrl(resizeForThumbnail(image), extension);
         } catch (IOException e) {
-            log.info(e.getMessage());
-            throw new RuntimeException();
+            log.error(e.getMessage());
+            throw new FileUploadFailedException();
         }
 
         return new ImageInfo(originalUrl, thumbnailUrl);

--- a/src/main/java/com/nexters/keyme/member/presentation/handler/MemberStateHandler.java
+++ b/src/main/java/com/nexters/keyme/member/presentation/handler/MemberStateHandler.java
@@ -1,0 +1,17 @@
+package com.nexters.keyme.member.presentation.handler;
+
+
+import com.nexters.keyme.common.dto.response.ApiResponse;
+import com.nexters.keyme.member.domain.exceptions.NicknameVerificationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class MemberStateHandler {
+    @ExceptionHandler(NicknameVerificationException.class)
+    public ResponseEntity<ApiResponse> handleNicknameVerificationException(NicknameVerificationException e) {
+        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>(e.getState(), e.getMessage(), null));
+    }
+}


### PR DESCRIPTION
### Summary
- Member 도메인에서 발생하는 State를 정의하고,  전역 예외처리 시 ApiResponse를 사용하도록 변경했습니다.

### Description
- MemberStateCode 및 핸들러 정의: 닉네임 중복과 길이제한 초과만 작성되어 있는 상태입니다.
- 파일 업로드 실패 예외 추가: FileUploadFailedException을 정의하고 ErrorCode에도 반영했습니다.
- GlobalExceptionHandler ApiResponse 사용하도록 변경: 기존 CommonResponse에서 ApiResponse로 변경했습니다.