### PR TITLE
멤버 수정 기능 버그 수정

### DIFF
--- a/src/main/java/com/nexters/keyme/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/nexters/keyme/member/presentation/controller/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
     @PatchMapping
     @ApiOperation("회원 정보 수정")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
-    public ResponseEntity<ApiResponse<MemberResponse>> verifyNickname(MemberModificationRequest request, @RequestUser UserInfo userInfo) {
+    public ResponseEntity<ApiResponse<MemberResponse>> verifyNickname(@RequestBody MemberModificationRequest request, @RequestUser UserInfo userInfo) {
         MemberResponse response = memberService.modifyMemberInfo(request, userInfo);
         return ResponseEntity.ok(new ApiResponse<>(response));
     }


### PR DESCRIPTION
close #51 

### Summary
- 멤버 업데이트 기능 동작이 안 되는 버그를 픽스했습니다.

### Description
- @RequestUser와 함께 복수의 인자를 받는 컨트롤러 메서드에서 @RequestBody를 누락해 발생하는 문제. 해당 애노테이션 추가하여 수정했습니다.