### PR TITLE
멤버 정보 수정 시 null 체크 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/member/domain/model/MemberEntity.java
+++ b/src/main/java/com/nexters/keyme/member/domain/model/MemberEntity.java
@@ -35,7 +35,12 @@ public class MemberEntity extends BaseTimeEntity {
     private ProfileImage profileImage;
 
     public void modifyMemberInfo(MemberModificationInfo modificationInfo) {
-        this.nickname = modificationInfo.getNickname();
-        this.profileImage = new ProfileImage(modificationInfo.getOriginalImage(), modificationInfo.getThumbnailImage());
+        if (modificationInfo.getNickname() != null) {
+            this.nickname = modificationInfo.getNickname();
+        }
+
+        if (modificationInfo.getOriginalImage() != null) {
+            this.profileImage = new ProfileImage(modificationInfo.getOriginalImage(), modificationInfo.getThumbnailImage());
+        }
     }
 }

--- a/src/main/java/com/nexters/keyme/member/domain/model/MemberEntity.java
+++ b/src/main/java/com/nexters/keyme/member/domain/model/MemberEntity.java
@@ -39,7 +39,7 @@ public class MemberEntity extends BaseTimeEntity {
             this.nickname = modificationInfo.getNickname();
         }
 
-        if (modificationInfo.getOriginalImage() != null) {
+        if (modificationInfo.getOriginalImage() != null && modificationInfo.getThumbnailImage() != null) {
             this.profileImage = new ProfileImage(modificationInfo.getOriginalImage(), modificationInfo.getThumbnailImage());
         }
     }

--- a/src/main/java/com/nexters/keyme/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/nexters/keyme/member/presentation/controller/MemberController.java
@@ -42,7 +42,7 @@ public class MemberController {
     @PatchMapping
     @ApiOperation("회원 정보 수정")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
-    public ResponseEntity<ApiResponse<MemberResponse>> verifyNickname(@RequestBody MemberModificationRequest request, @RequestUser UserInfo userInfo) {
+    public ResponseEntity<ApiResponse<MemberResponse>> modifyMemberInfo(@RequestBody MemberModificationRequest request, @RequestUser UserInfo userInfo) {
         MemberResponse response = memberService.modifyMemberInfo(request, userInfo);
         return ResponseEntity.ok(new ApiResponse<>(response));
     }

--- a/src/test/java/com/nexters/keyme/member/domain/model/MemberEntityTest.java
+++ b/src/test/java/com/nexters/keyme/member/domain/model/MemberEntityTest.java
@@ -9,8 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MemberEntityTest {
 
     @Test
-    @DisplayName("멤버 정보 수정 테스트")
-    void modifyMemberInfo() {
+    @DisplayName("수정 요청 필드에 null이 없을 때에는 닉네임과 이미지를 모두 수정한다")
+    void modifyAllFieldsTest() {
         MemberEntity member = MemberEntity.builder()
                 .id(1L)
                 .nickname("nicknameOne")
@@ -29,5 +29,64 @@ class MemberEntityTest {
         assertThat(member.getNickname()).isEqualTo("nicknameTwo");
         assertThat(member.getProfileImage().getOriginalUrl()).isEqualTo("originalTwo");
         assertThat(member.getProfileImage().getThumbnailUrl()).isEqualTo("thumbnailTwo");
+    }
+
+    @Test
+    @DisplayName("수정 요청 필드 중 닉네임이 null일 때에는 섬네일만 수정한다")
+    void modifyProfileImageOnlyTest() {
+        MemberEntity member = MemberEntity.builder()
+                .id(1L)
+                .nickname("nicknameOne")
+                .profileImage(new ProfileImage("originalOne", "thumbnailOne"))
+                .build();
+
+        MemberModificationInfo request = MemberModificationInfo.builder()
+                .nickname(null)
+                .originalImage("originalTwo")
+                .thumbnailImage("thumbnailTwo")
+                .build();
+
+        member.modifyMemberInfo(request);
+
+        assertThat(member.getId()).isEqualTo(1L);
+        assertThat(member.getNickname()).isEqualTo("nicknameOne");
+        assertThat(member.getProfileImage().getOriginalUrl()).isEqualTo("originalTwo");
+        assertThat(member.getProfileImage().getThumbnailUrl()).isEqualTo("thumbnailTwo");
+    }
+
+    @Test
+    @DisplayName("수정 요청 필드 중 프로필 사진 원본/섬네일 중 일부가 null일 때에는 프로필 사진을 업데이트하지 않는다.")
+    void modifyNicknameOnlyTest() {
+        MemberEntity member = MemberEntity.builder()
+                .id(1L)
+                .nickname("nicknameOne")
+                .profileImage(new ProfileImage("originalOne", "thumbnailOne"))
+                .build();
+
+        MemberModificationInfo requestOne = MemberModificationInfo.builder()
+                .nickname("nicknameTwo")
+                .originalImage("originalTwo")
+                .thumbnailImage(null)
+                .build();
+
+        MemberModificationInfo requestTwo = MemberModificationInfo.builder()
+                .nickname("nicknameTwo")
+                .originalImage(null)
+                .thumbnailImage("thumbnailTwo")
+                .build();
+
+        member.modifyMemberInfo(requestOne);
+
+        assertThat(member.getId()).isEqualTo(1L);
+        assertThat(member.getNickname()).isEqualTo("nicknameTwo");
+        assertThat(member.getProfileImage().getOriginalUrl()).isEqualTo("originalOne");
+        assertThat(member.getProfileImage().getThumbnailUrl()).isEqualTo("thumbnailOne");
+
+        member.modifyMemberInfo(requestTwo);
+
+        assertThat(member.getId()).isEqualTo(1L);
+        assertThat(member.getNickname()).isEqualTo("nicknameTwo");
+        assertThat(member.getProfileImage().getOriginalUrl()).isEqualTo("originalOne");
+        assertThat(member.getProfileImage().getThumbnailUrl()).isEqualTo("thumbnailOne");
     }
 }


### PR DESCRIPTION
close #53 

### Summary
- 멤버 정보 수정 컨트롤러 메서드명을 변경했습니다.
- 멤버 정보 수정 시, 요청 필드에 null이 있을 경우 해당 필드를 업데이트하지 않도록 수정했습니다.

### Description
- 멤버 수정 컨트롤러 메서드명 `verifyNickname` -> `modifyMemberInfo`로 수정
- 멤버 정보 수정 시 null로 요청이 들어온 필드는 업데이트 하지 않도록 수정: 프로필 이미지의 경우 원본과 섬네일 필드가 모두 들어와야 수정하도록 처리했습니다.
- 멤버 수정 시 null 체크 관련 단위테스트 케이스 추가