### PR TITLE
Quetion 통계 관련된 API 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/common/dto/request/PaginationRequest.java
+++ b/src/main/java/com/nexters/keyme/common/dto/request/PaginationRequest.java
@@ -13,6 +13,6 @@ public class PaginationRequest {
     @ApiModelProperty(value = "가져올 갯수", example = "10")
     private int limit = 10;
 
-    @ApiModelProperty(value = "마지막 게시글의 Id", example = "123")
+    @ApiModelProperty(value = "마지막 게시글의 Id(첫 요청시에는 없어도 됨)", example = "123")
     private Long cursor;
 }

--- a/src/main/java/com/nexters/keyme/question/application/QuestionService.java
+++ b/src/main/java/com/nexters/keyme/question/application/QuestionService.java
@@ -1,7 +1,16 @@
 package com.nexters.keyme.question.application;
 
+import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedListRequest;
+import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedRequest;
+import com.nexters.keyme.question.presentation.dto.request.QuestionStatisticRequest;
 import com.nexters.keyme.question.presentation.dto.response.QuestionResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedListResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 
 public interface QuestionService {
     QuestionResponse getQuestion(Long questionId);
+    QuestionSolvedResponse getQuestionSolvedScore(QuestionSolvedRequest request);
+    QuestionStatisticResponse getQuestionStatistics(QuestionStatisticRequest request);
+    QuestionSolvedListResponse getQuestionSolvedList(QuestionSolvedListRequest request);
 }

--- a/src/main/java/com/nexters/keyme/question/application/QuestionService.java
+++ b/src/main/java/com/nexters/keyme/question/application/QuestionService.java
@@ -10,7 +10,7 @@ import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticRes
 
 public interface QuestionService {
     QuestionResponse getQuestion(Long questionId);
-    QuestionSolvedResponse getQuestionSolvedScore(QuestionSolvedRequest request);
-    QuestionStatisticResponse getQuestionStatistics(QuestionStatisticRequest request);
-    QuestionSolvedListResponse getQuestionSolvedList(QuestionSolvedListRequest request);
+    QuestionSolvedResponse getQuestionSolvedScore(Long questionId, QuestionSolvedRequest request);
+    QuestionStatisticResponse getQuestionStatistic(Long questionId, QuestionStatisticRequest request);
+    QuestionSolvedListResponse getQuestionSolvedList(Long questionId, QuestionSolvedListRequest request);
 }

--- a/src/main/java/com/nexters/keyme/question/application/QuestionServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/question/application/QuestionServiceImpl.java
@@ -1,4 +1,37 @@
 package com.nexters.keyme.question.application;
 
-public class QuestionServiceImpl {
+import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedListRequest;
+import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedRequest;
+import com.nexters.keyme.question.presentation.dto.request.QuestionStatisticRequest;
+import com.nexters.keyme.question.presentation.dto.response.QuestionResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedListResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionServiceImpl implements QuestionService {
+
+
+    @Override
+    public QuestionResponse getQuestion(Long questionId) {
+        return null;
+    }
+
+    @Override
+    public QuestionSolvedResponse getQuestionSolvedScore(QuestionSolvedRequest request) {
+        return null;
+    }
+
+    @Override
+    public QuestionStatisticResponse getQuestionStatistics(QuestionStatisticRequest request) {
+        return null;
+    }
+
+    @Override
+    public QuestionSolvedListResponse getQuestionSolvedList(QuestionSolvedListRequest request) {
+        return null;
+    }
 }

--- a/src/main/java/com/nexters/keyme/question/application/QuestionServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/question/application/QuestionServiceImpl.java
@@ -1,5 +1,13 @@
 package com.nexters.keyme.question.application;
 
+import com.nexters.keyme.common.exceptions.ResourceNotFoundException;
+import com.nexters.keyme.member.domain.model.MemberEntity;
+import com.nexters.keyme.member.domain.repository.MemberRepository;
+import com.nexters.keyme.question.domain.internaldto.QuestionStatisticInfo;
+import com.nexters.keyme.question.domain.model.Question;
+import com.nexters.keyme.question.domain.model.QuestionSolved;
+import com.nexters.keyme.question.domain.repository.QuestionRepository;
+import com.nexters.keyme.question.domain.repository.QuestionSolvedRepository;
 import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedListRequest;
 import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedRequest;
 import com.nexters.keyme.question.presentation.dto.request.QuestionStatisticRequest;
@@ -8,30 +16,46 @@ import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedListRe
 import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedResponse;
 import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionServiceImpl implements QuestionService {
-
+    private final QuestionRepository questionRepository;
+    private final QuestionSolvedRepository questionSolvedRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public QuestionResponse getQuestion(Long questionId) {
-        return null;
+        Question question = questionRepository.findById(questionId).orElseThrow(ResourceNotFoundException::new);
+        return new QuestionResponse(question);
     }
 
     @Override
-    public QuestionSolvedResponse getQuestionSolvedScore(QuestionSolvedRequest request) {
-        return null;
+    public QuestionSolvedResponse getQuestionSolvedScore(Long questionId, QuestionSolvedRequest request) {
+        Question question = questionRepository.findById(questionId).orElseThrow(ResourceNotFoundException::new);
+        MemberEntity member = memberRepository.findById(request.getOwnerId()).orElseThrow(ResourceNotFoundException::new);
+        QuestionSolved questionSolved = questionSolvedRepository.findByQuestionAndOwner(question, member).orElseThrow(ResourceNotFoundException::new);
+
+        return new QuestionSolvedResponse(questionSolved);
     }
 
     @Override
-    public QuestionStatisticResponse getQuestionStatistics(QuestionStatisticRequest request) {
-        return null;
+    public QuestionStatisticResponse getQuestionStatistic(Long questionId, QuestionStatisticRequest request) {
+        Question question = questionRepository.findById(questionId).orElseThrow(ResourceNotFoundException::new);
+        MemberEntity member = memberRepository.findById(request.getOwnerId()).orElseThrow(ResourceNotFoundException::new);
+        QuestionStatisticInfo questionStatisticInfo = questionSolvedRepository.findQuestionStatisticsByQuestionIdAndOwnerId(questionId, request.getOwnerId()).orElseThrow(ResourceNotFoundException::new);
+
+        return new QuestionStatisticResponse(questionStatisticInfo);
     }
 
     @Override
-    public QuestionSolvedListResponse getQuestionSolvedList(QuestionSolvedListRequest request) {
+    public QuestionSolvedListResponse getQuestionSolvedList(Long questionId, QuestionSolvedListRequest request) {
+
         return null;
     }
 }

--- a/src/main/java/com/nexters/keyme/question/domain/model/QuestionSolved.java
+++ b/src/main/java/com/nexters/keyme/question/domain/model/QuestionSolved.java
@@ -1,6 +1,7 @@
 package com.nexters.keyme.question.domain.model;
 
 import com.nexters.keyme.common.model.BaseTimeEntity;
+import com.nexters.keyme.member.domain.model.MemberEntity;
 import com.nexters.keyme.question.presentation.dto.response.QuestionCategoryResponse;
 import com.nexters.keyme.question.presentation.dto.response.QuestionResponse;
 import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedResponse;
@@ -28,6 +29,10 @@ public class QuestionSolved extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_owner_id")
+    private MemberEntity owner;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "test_result_id")

--- a/src/main/java/com/nexters/keyme/question/domain/repository/QuestionSolvedRepository.java
+++ b/src/main/java/com/nexters/keyme/question/domain/repository/QuestionSolvedRepository.java
@@ -1,6 +1,8 @@
 package com.nexters.keyme.question.domain.repository;
 
+import com.nexters.keyme.member.domain.model.MemberEntity;
 import com.nexters.keyme.question.domain.internaldto.QuestionStatisticInfo;
+import com.nexters.keyme.question.domain.model.Question;
 import com.nexters.keyme.question.domain.model.QuestionSolved;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -28,7 +30,19 @@ public interface QuestionSolvedRepository extends JpaRepository<QuestionSolved, 
         "select new com.nexters.keyme.question.domain.internaldto.QuestionStatisticInfo(qs.question.questionId, qs.question.title, qs.question.keyword, qs.question.categoryName, avg(qs.score)) " +
             "from QuestionSolved qs " +
             "where qs.testResult.test.testId = :testId " +
+                "and qs.testResult.solver.id != qs.owner.id " +
             "group by qs.question.questionId "
     )
     List<QuestionStatisticInfo> findAllAssociatedQuestionStatisticsByTestId(Long testId);
+
+    @Query(
+        "select new com.nexters.keyme.question.domain.internaldto.QuestionStatisticInfo(qs.question.questionId, qs.question.title, qs.question.keyword, qs.question.categoryName, avg(qs.score)) " +
+            "from QuestionSolved qs " +
+            "where qs.question.questionId = :questionId " +
+                "and qs.owner.id = :ownerId " +
+                "and qs.testResult.solver.id != :ownerId"
+    )
+    Optional<QuestionStatisticInfo> findQuestionStatisticsByQuestionIdAndOwnerId(Long questionId, Long ownerId);
+
+    Optional<QuestionSolved> findByQuestionAndOwner(Question question, MemberEntity owner);
 }

--- a/src/main/java/com/nexters/keyme/question/presentation/controller/QuestionController.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/controller/QuestionController.java
@@ -1,7 +1,14 @@
 package com.nexters.keyme.question.presentation.controller;
 
 import com.nexters.keyme.common.dto.response.ApiResponse;
+import com.nexters.keyme.question.application.QuestionService;
+import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedListRequest;
+import com.nexters.keyme.question.presentation.dto.request.QuestionSolvedRequest;
+import com.nexters.keyme.question.presentation.dto.request.QuestionStatisticRequest;
 import com.nexters.keyme.question.presentation.dto.response.QuestionResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedListResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionSolvedResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -16,16 +23,41 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/questions")
 @RequiredArgsConstructor
 public class QuestionController {
+    private final QuestionService questionService;
 
     @GetMapping("/{id}")
     @ApiOperation(value = "질문 정보 가져오기")
     public ResponseEntity<ApiResponse<QuestionResponse>> questionDetail(@PathVariable("id") Long questionid) {
-        return ResponseEntity
-                .ok(new ApiResponse<>(new QuestionResponse()));
+        QuestionResponse questionResponse = questionService.getQuestion(questionid);
+        return ResponseEntity.ok(new ApiResponse<>(questionResponse));
     }
 
-    @GetMapping("/{id}/solved-members")
-    public ResponseEntity<ApiResponse> questionSolved(Long questionid, Long solverId) {
+    @GetMapping("/{id}/score")
+    @ApiOperation(value = "Question 점수 가져오기")
+    public ResponseEntity<ApiResponse<QuestionSolvedResponse>> getQuestionSolvedScore(
+        @PathVariable("id") Long questionId,
+        QuestionSolvedRequest request
+    ) {
+        QuestionSolvedResponse questionSolvedResponse = questionService.getQuestionSolvedScore(questionId, request);
+        return ResponseEntity.ok(new ApiResponse<>(questionSolvedResponse));
+    }
+
+    @GetMapping("/{id}/statistics")
+    @ApiOperation(value = "Question 통계 가져오기")
+    public ResponseEntity<ApiResponse<QuestionStatisticResponse>> getQuestionStatistic(
+        @PathVariable("id") Long questionId,
+        QuestionStatisticRequest request
+    ) {
+        QuestionStatisticResponse questionStatisticResponse = questionService.getQuestionStatistic(questionId, request);
+        return ResponseEntity.ok(new ApiResponse<>(questionStatisticResponse));
+    }
+
+
+    @GetMapping("/{id}/solved-scores")
+    public ResponseEntity<ApiResponse<QuestionSolvedListResponse>> getQuestionSolvedList(
+        @PathVariable("id") Long questionId,
+        QuestionSolvedListRequest request
+    ) {
         return null;
     }
 }

--- a/src/main/java/com/nexters/keyme/question/presentation/dto/request/QuestionSolvedListRequest.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/dto/request/QuestionSolvedListRequest.java
@@ -1,0 +1,15 @@
+package com.nexters.keyme.question.presentation.dto.request;
+
+import com.nexters.keyme.common.dto.request.PaginationRequest;
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@ApiModel("Question을 푼 사람들의 점수리스트 요청 객체")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionSolvedListRequest extends PaginationRequest {
+    private Long ownerId;
+}

--- a/src/main/java/com/nexters/keyme/question/presentation/dto/request/QuestionSolvedRequest.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/dto/request/QuestionSolvedRequest.java
@@ -1,0 +1,15 @@
+package com.nexters.keyme.question.presentation.dto.request;
+
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@ApiModel("Question 점수 요청 객체")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionSolvedRequest {
+    private Long ownerId;
+}

--- a/src/main/java/com/nexters/keyme/question/presentation/dto/request/QuestionStatisticRequest.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/dto/request/QuestionStatisticRequest.java
@@ -1,0 +1,14 @@
+package com.nexters.keyme.question.presentation.dto.request;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@ApiModel("Question의 통계 요청 객체")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionStatisticRequest {
+    private Long ownerId;
+}

--- a/src/main/java/com/nexters/keyme/question/presentation/dto/response/QuestionSolvedListResponse.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/dto/response/QuestionSolvedListResponse.java
@@ -1,0 +1,23 @@
+package com.nexters.keyme.question.presentation.dto.response;
+
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@ApiModel(value = "Question을 푼 사람들의 점수리스트")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class QuestionSolvedListResponse {
+
+    @ApiModelProperty(value = "전체 count", example = "123")
+    private Long count;
+    private List<QuestionSolvedSimpleResponse> results;
+}

--- a/src/main/java/com/nexters/keyme/question/presentation/dto/response/QuestionSolvedSimpleResponse.java
+++ b/src/main/java/com/nexters/keyme/question/presentation/dto/response/QuestionSolvedSimpleResponse.java
@@ -1,0 +1,18 @@
+package com.nexters.keyme.question.presentation.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class QuestionSolvedSimpleResponse {
+    private int score;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/nexters/keyme/test/application/TestServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/test/application/TestServiceImpl.java
@@ -201,6 +201,7 @@ public class TestServiceImpl implements TestService {
                 .map(questionResult -> QuestionSolved.builder()
                         .question(new Question(questionResult.getQuestionId()))
                         .score(questionResult.getScore())
+                        .owner(test.getMember())
                         .testResult(testResult)
                         .build()
                 )


### PR DESCRIPTION
### Issue Tag
- close #57

### Summary
- Question Score, Question Statistics, Question ScoreList API 구현

### Description
- Question ScoreList는 API만 구현하였고 비즈니스 로직은 이후에 추가하겠습니다.