### PR TITLE
멤버 성격 더보기 기능 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticService.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticService.java
@@ -3,6 +3,7 @@ package com.nexters.keyme.statistics.application;
 import com.nexters.keyme.statistics.application.dto.ScoreInfo;
 import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
 import com.nexters.keyme.statistics.domain.model.Statistic;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.MemberStatisticResponse;
@@ -15,5 +16,5 @@ public interface StatisticService {
 
     MemberStatisticResponse getMemberStatistic(long memberId, StatisticRequest request);
 
-    List<AdditionalStatisticResponse> getAdditionalStatistics (long memberId, long cursor);
+    List<AdditionalStatisticResponse> getAdditionalStatistics (long memberId, AdditionalStatisticRequest request);
 }

--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticService.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticService.java
@@ -3,8 +3,11 @@ package com.nexters.keyme.statistics.application;
 import com.nexters.keyme.statistics.application.dto.ScoreInfo;
 import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
 import com.nexters.keyme.statistics.domain.model.Statistic;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.MemberStatisticResponse;
+
+import java.util.List;
 
 public interface StatisticService {
     Statistic createStatistic(StatisticInfo statisticInfo);
@@ -12,4 +15,5 @@ public interface StatisticService {
 
     MemberStatisticResponse getMemberStatistic(long memberId, StatisticRequest request);
 
+    List<AdditionalStatisticResponse> getAdditionalStatistics (long memberId, long cursor);
 }

--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -96,9 +96,7 @@ public class StatisticServiceImpl implements StatisticService {
                 .map(Statistic::getQuestionId)
                 .collect(Collectors.toList());
 
-        Statistic cursorStatistic = statisticRepository.findById(cursor)
-                .orElseThrow(ResourceNotFoundException::new);
-
+        Statistic cursorStatistic = getCursorStatistic(cursor);
         double cursorScore = cursorStatistic.getSolverAvgScore();
 
         List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(exceptIds, cursor, cursorScore);
@@ -110,5 +108,17 @@ public class StatisticServiceImpl implements StatisticService {
                     return new AdditionalStatisticResponse(statistic.getId(), question.getKeyword(), statistic.getSolverAvgScore());
                 })
                 .collect(Collectors.toList());
+    }
+
+    private Statistic getCursorStatistic(long cursor) {
+        if (cursor == 0) {
+            return Statistic.builder()
+                    .id(0)
+                    .solverAvgScore(Double.MAX_VALUE)
+                    .build();
+        }
+
+        return statisticRepository.findById(cursor)
+                    .orElseThrow(ResourceNotFoundException::new);
     }
 }

--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -107,7 +107,7 @@ public class StatisticServiceImpl implements StatisticService {
                 .map((statistic) -> {
                     Question question = questionRepository.findById(statistic.getQuestionId())
                             .orElseThrow(ResourceNotFoundException::new);
-                    return new AdditionalStatisticResponse(question.getKeyword(), statistic.getSolverAvgScore());
+                    return new AdditionalStatisticResponse(statistic.getId(), question.getKeyword(), statistic.getSolverAvgScore());
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -106,7 +106,7 @@ public class StatisticServiceImpl implements StatisticService {
                 .map((statistic) -> {
                     Question question = questionRepository.findById(statistic.getQuestionId())
                             .orElseThrow(ResourceNotFoundException::new);
-                    return new AdditionalStatisticResponse(statistic.getId(), question.getKeyword(), statistic.getSolverAvgScore());
+                    return new AdditionalStatisticResponse(statistic.getId(), question.getKeyword(), question.getCategoryName().getColor(), question.getCategoryName().getImageUrl(), statistic.getSolverAvgScore());
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -9,6 +9,7 @@ import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
 import com.nexters.keyme.statistics.domain.model.Statistic;
 import com.nexters.keyme.statistics.domain.repository.StatisticRepository;
 import com.nexters.keyme.statistics.domain.service.CoordinateConversionService;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.CoordinateResponse;
@@ -88,7 +89,7 @@ public class StatisticServiceImpl implements StatisticService {
 
     @Transactional
     @Override
-    public List<AdditionalStatisticResponse> getAdditionalStatistics (long memberId, long cursor) {
+    public List<AdditionalStatisticResponse> getAdditionalStatistics (long memberId, AdditionalStatisticRequest request) {
         List<Statistic> differentStatistics = statisticRepository.findByMemberIdSortByMatchRateAsc(memberId);
         List<Statistic> similarStatistics = statisticRepository.findByMemberIdSortByMatchRateDesc(memberId);
 
@@ -96,10 +97,10 @@ public class StatisticServiceImpl implements StatisticService {
                 .map(Statistic::getQuestionId)
                 .collect(Collectors.toList());
 
-        Statistic cursorStatistic = getCursorStatistic(cursor);
+        Statistic cursorStatistic = getCursorStatistic(request.getCursor());
         double cursorScore = cursorStatistic.getSolverAvgScore();
 
-        List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(exceptIds, cursor, cursorScore);
+        List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(exceptIds, request.getCursor(), cursorScore, request.getLimit());
 
         return statistics.stream()
                 .map((statistic) -> {

--- a/src/main/java/com/nexters/keyme/statistics/domain/repository/StatisticRepository.java
+++ b/src/main/java/com/nexters/keyme/statistics/domain/repository/StatisticRepository.java
@@ -21,6 +21,7 @@ public interface StatisticRepository extends JpaRepository<Statistic, Long> {
     @Query(value = "SELECT * FROM statistic st WHERE st.owner_id = :memberId ORDER BY st.match_rate DESC LIMIT 5", nativeQuery = true)
     List<Statistic> findByMemberIdSortByMatchRateDesc(long memberId);
 
-//    @Query("SELECT st FROM Statistic st WHERE st.ownerId = :memberId ORDER BY st.matchRate")
-//    List<Statistic> findByMemberId(long memberId, String sortBy);
+    @Query(value = "SELECT * FROM statistic st WHERE (st.solver_avg_score < :cursorScore OR st.solver_avg_score = :cursorScore AND st.id > :cursor) AND st.id NOT IN :exceptIds ORDER BY st.match_rate DESC, st.id LIMIT 5", nativeQuery = true)
+    List<Statistic> findExceptIdsSortByAvgScore(List<Long> exceptIds, long cursor, double cursorScore);
+
 }

--- a/src/main/java/com/nexters/keyme/statistics/domain/repository/StatisticRepository.java
+++ b/src/main/java/com/nexters/keyme/statistics/domain/repository/StatisticRepository.java
@@ -21,7 +21,7 @@ public interface StatisticRepository extends JpaRepository<Statistic, Long> {
     @Query(value = "SELECT * FROM statistic st WHERE st.owner_id = :memberId ORDER BY st.match_rate DESC LIMIT 5", nativeQuery = true)
     List<Statistic> findByMemberIdSortByMatchRateDesc(long memberId);
 
-    @Query(value = "SELECT * FROM statistic st WHERE (st.solver_avg_score < :cursorScore OR st.solver_avg_score = :cursorScore AND st.id > :cursor) AND st.id NOT IN :exceptIds ORDER BY st.match_rate DESC, st.id LIMIT 5", nativeQuery = true)
-    List<Statistic> findExceptIdsSortByAvgScore(List<Long> exceptIds, long cursor, double cursorScore);
+    @Query(value = "SELECT * FROM statistic st WHERE (st.solver_avg_score < :cursorScore OR st.solver_avg_score = :cursorScore AND st.id > :cursor) AND st.id NOT IN :exceptIds ORDER BY st.match_rate DESC, st.id LIMIT :limit", nativeQuery = true)
+    List<Statistic> findExceptIdsSortByAvgScore(List<Long> exceptIds, long cursor, double cursorScore, int limit);
 
 }

--- a/src/main/java/com/nexters/keyme/statistics/infrastcurture/PythonCoordinateConversionService.java
+++ b/src/main/java/com/nexters/keyme/statistics/infrastcurture/PythonCoordinateConversionService.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 @Service
 public class PythonCoordinateConversionService implements CoordinateConversionService {
     @Value("${python-server}")
-    private String ConvertingServerUrl;
+    private String convertingServerUrl;
     @Override
     public List<CoordinateInfo> convertFrom(List<Statistic> statistics) {
         List<Double> collect = statistics.stream()
@@ -26,7 +26,7 @@ public class PythonCoordinateConversionService implements CoordinateConversionSe
                 .collect(Collectors.toList());
 
         CoordinateResponse response = WebClient.create().post()
-                .uri("http://101.101.216.41:8000/circle")
+                .uri(convertingServerUrl)
                 .bodyValue(new CoordinateRequest(collect))
                 .accept(MediaType.APPLICATION_JSON)
                 .acceptCharset(StandardCharsets.UTF_8)

--- a/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticController.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticController.java
@@ -20,7 +20,7 @@ import static com.nexters.keyme.common.config.SwaggerConfig.SWAGGER_AUTHORIZATIO
 @Api(tags = "마이페이지(통계)", description = "멤버 마이페이지 관련 API")
 public class StatisticController {
     private final StatisticService statisticService;
-    @GetMapping("/members/{memberId}/stataistics")
+    @GetMapping("/members/{memberId}/statistics")
     @ApiOperation(value = "멤버의 성격 통계 보기")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse<MemberStatisticResponse>> getMemberStatistic(@PathVariable(name = "memberId") Long memberId,

--- a/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticController.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticController.java
@@ -2,6 +2,7 @@ package com.nexters.keyme.statistics.presentation.controller;
 
 import com.nexters.keyme.common.dto.response.ApiResponse;
 import com.nexters.keyme.statistics.application.StatisticService;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.MemberStatisticResponse;
 import io.swagger.annotations.Api;
@@ -11,7 +12,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static com.nexters.keyme.common.config.SwaggerConfig.SWAGGER_AUTHORIZATION_SCHEME;
 
@@ -26,6 +30,15 @@ public class StatisticController {
     public ResponseEntity<ApiResponse<MemberStatisticResponse>> getMemberStatistic(@PathVariable(name = "memberId") Long memberId,
                                                                                    StatisticRequest request) {
         MemberStatisticResponse response = statisticService.getMemberStatistic(memberId, request);
+        return ResponseEntity.ok(new ApiResponse<>(response));
+    }
+
+    @GetMapping("/members/{memberId}/statistics/more")
+    @ApiOperation(value = "멤버의 성격 더보기")
+    @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
+    public ResponseEntity<ApiResponse<List<AdditionalStatisticResponse>>> getMemberStatistic(@PathVariable(name = "memberId") Long memberId,
+                                                                                             @RequestParam long cursorId) {
+        List<AdditionalStatisticResponse> response = statisticService.getAdditionalStatistics(memberId, cursorId);
         return ResponseEntity.ok(new ApiResponse<>(response));
     }
 }

--- a/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticController.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/controller/StatisticController.java
@@ -2,6 +2,7 @@ package com.nexters.keyme.statistics.presentation.controller;
 
 import com.nexters.keyme.common.dto.response.ApiResponse;
 import com.nexters.keyme.statistics.application.StatisticService;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.MemberStatisticResponse;
@@ -12,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -37,8 +37,8 @@ public class StatisticController {
     @ApiOperation(value = "멤버의 성격 더보기")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
     public ResponseEntity<ApiResponse<List<AdditionalStatisticResponse>>> getMemberStatistic(@PathVariable(name = "memberId") Long memberId,
-                                                                                             @RequestParam long cursorId) {
-        List<AdditionalStatisticResponse> response = statisticService.getAdditionalStatistics(memberId, cursorId);
+                                                                                             AdditionalStatisticRequest request) {
+        List<AdditionalStatisticResponse> response = statisticService.getAdditionalStatistics(memberId, request);
         return ResponseEntity.ok(new ApiResponse<>(response));
     }
 }

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticRequest.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticRequest.java
@@ -1,0 +1,20 @@
+package com.nexters.keyme.statistics.presentation.dto;
+
+import com.nexters.keyme.common.dto.request.PaginationRequest;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+public class AdditionalStatisticRequest {
+    @ApiModelProperty(value = "가져올 갯수", example = "10")
+    private int limit = 10;
+
+    @ApiModelProperty(value = "마지막 게시글의 Id(첫 요청시에는 없어도 됨)", example = "123")
+    private Long cursor;
+
+    public AdditionalStatisticRequest(int limit, Long cursor) {
+        this.limit = limit;
+        this.cursor = cursor;
+    }
+}

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public class AdditionalStatisticResponse {
+    private final long statisticId;
     private final String keyword;
     private final double solverAvgScore;
 }

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
@@ -1,0 +1,12 @@
+package com.nexters.keyme.statistics.presentation.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@RequiredArgsConstructor
+@Getter
+public class AdditionalStatisticResponse {
+    private final String keyword;
+    private final double solverAvgScore;
+}

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
@@ -12,6 +12,10 @@ public class AdditionalStatisticResponse {
     private final long statisticId;
     @ApiModelProperty(value="문제 키워드", example = "소통왕")
     private final String keyword;
+    @ApiModelProperty(value="카테고리 색상", example = "FFFFFF")
+    private final String categoryColor;
+    @ApiModelProperty(value="카테고리 아이콘 url", example = "(path)")
+    private final String categoryIconUrl;
     @ApiModelProperty(value="푼 사람들의 평균 점수", example = "1.5")
     private final double solverAvgScore;
 }

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/AdditionalStatisticResponse.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.statistics.presentation.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +8,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public class AdditionalStatisticResponse {
+    @ApiModelProperty(value="통계 정보 id", example = "1")
     private final long statisticId;
+    @ApiModelProperty(value="문제 키워드", example = "소통왕")
     private final String keyword;
+    @ApiModelProperty(value="푼 사람들의 평균 점수", example = "1.5")
     private final double solverAvgScore;
 }

--- a/src/test/java/com/nexters/keyme/statistics/application/StatisticServiceTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/application/StatisticServiceTest.java
@@ -3,6 +3,7 @@ package com.nexters.keyme.statistics.application;
 import com.nexters.keyme.statistics.application.dto.ScoreInfo;
 import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
 import com.nexters.keyme.statistics.domain.model.Statistic;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.*;
 import org.junit.jupiter.api.DisplayName;
@@ -69,6 +70,13 @@ class StatisticServiceTest {
         assertThat(coordinate.getX()).isEqualTo(0.2947799111389068);
         assertThat(coordinate.getY()).isEqualTo(0.6534475680919012);
         assertThat(coordinate.getR()).isEqualTo(0.28313953920146934);
+    }
 
+    @Test
+    @DisplayName("유저 성격 더보기 테스트")
+    void viewAdditionalStatisticTest() {
+        List<AdditionalStatisticResponse> response = statisticService.getAdditionalStatistics(1L, 0L);
+
+        assertThat(response.size()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/nexters/keyme/statistics/application/StatisticServiceTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/application/StatisticServiceTest.java
@@ -3,6 +3,7 @@ package com.nexters.keyme.statistics.application;
 import com.nexters.keyme.statistics.application.dto.ScoreInfo;
 import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
 import com.nexters.keyme.statistics.domain.model.Statistic;
+import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.*;
@@ -75,7 +76,7 @@ class StatisticServiceTest {
     @Test
     @DisplayName("유저 성격 더보기 테스트")
     void viewAdditionalStatisticTest() {
-        List<AdditionalStatisticResponse> response = statisticService.getAdditionalStatistics(1L, 0L);
+        List<AdditionalStatisticResponse> response = statisticService.getAdditionalStatistics(1L, new AdditionalStatisticRequest(5, 0L));
 
         assertThat(response.size()).isEqualTo(0);
     }

--- a/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
@@ -56,4 +56,13 @@ class StatisticRepositoryTest {
         assertThat(statistics.get(3).getId()).isEqualTo(3);
         assertThat(statistics.get(4).getId()).isEqualTo(2);
     }
+
+    @Test
+    void findExceptIdsSortByAvgScoreTest() {
+        List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(List.of(1L, 2L), 6, 5);
+
+        assertThat(statistics.size()).isEqualTo(3);
+        assertThat(statistics.get(0).getId()).isEqualTo(5);
+        assertThat(statistics.get(statistics.size() - 1).getId()).isEqualTo(3);
+    }
 }

--- a/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
@@ -58,6 +58,7 @@ class StatisticRepositoryTest {
     }
 
     @Test
+    @DisplayName("특정 id 제외 통계 가져오기 테스트")
     void findExceptIdsSortByAvgScoreTest() {
         List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(List.of(1L, 2L), 6, 5);
 

--- a/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
@@ -60,7 +60,7 @@ class StatisticRepositoryTest {
     @Test
     @DisplayName("특정 id 제외 통계 가져오기 테스트")
     void findExceptIdsSortByAvgScoreTest() {
-        List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(List.of(1L, 2L), 6, 5);
+        List<Statistic> statistics = statisticRepository.findExceptIdsSortByAvgScore(List.of(1L, 2L), 6, 5, 5);
 
         assertThat(statistics.size()).isEqualTo(3);
         assertThat(statistics.get(0).getId()).isEqualTo(5);


### PR DESCRIPTION
### Summary
- 마이페이지에서 멤버의 성격 더보기를 눌렀을 때 목록을 응답하는 API를 구현합니다.

### Description
- 각 탭에서 원으로 표시된 항목을 제외하고 리스트로 반환하도록 했고, cursor와 limit을 받아 페이지네이션 처리를 구현했습니다.
- 추후 비정규화 등을 통해 쿼리 횟수를 줄이는 작업도 가능할 것 같습니다.