### PR TITLE
유저 통계정보 없을 시 404 리턴 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -71,7 +71,7 @@ public class StatisticServiceImpl implements StatisticService {
             statistics = statisticRepository.findByMemberIdSortByMatchRateDesc(memberId);
         }
 
-        if (statistics.size() > 5) {
+        if (checkStatisticExists(statistics)) {
             throw new ResourceNotFoundException();
         }
 
@@ -90,6 +90,10 @@ public class StatisticServiceImpl implements StatisticService {
         }
 
         return new MemberStatisticResponse(memberId, results);
+    }
+
+    private boolean checkStatisticExists(List<Statistic> statistics) {
+        return statistics.size() > 5;
     }
 
     @Transactional

--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -71,6 +71,10 @@ public class StatisticServiceImpl implements StatisticService {
             statistics = statisticRepository.findByMemberIdSortByMatchRateDesc(memberId);
         }
 
+        if (statistics.size() > 5) {
+            throw new ResourceNotFoundException();
+        }
+
         List<CoordinateInfo> coordinates = conversionService.convertFrom(statistics);
 
         List<StatisticResultResponse> results = new ArrayList<>();


### PR DESCRIPTION
### Issue
- close #81 

### Summary
- 유저 통계정보 보기 API에서, 유저의 통계 정보가 존재하지 않거나 유효한 상태가 아닐 경우 404를 리턴하도록 수정했습니다.

### Description
- statistics의 길이가 5 미만인 경우 404를 리턴합니다.