### PR TITLE
멤버 통계정보 추가 시 NPE 버그 수정

### DIFF
--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -57,6 +57,11 @@ public class StatisticServiceImpl implements StatisticService {
                     return createStatistic(info);
                 });
 
+        System.out.println("here!!!");
+//        System.out.println(scoreInfo.getSolverId());
+//        System.out.println(scoreInfo.getScore());
+//        System.out.println(statistic == null);
+
         statistic.addNewScore(scoreInfo.getSolverId(), scoreInfo.getScore());
     }
 

--- a/src/main/java/com/nexters/keyme/statistics/domain/model/Statistic.java
+++ b/src/main/java/com/nexters/keyme/statistics/domain/model/Statistic.java
@@ -33,8 +33,8 @@ public class Statistic extends BaseTimeEntity {
         this.ownerScore = ownerScore;
     }
 
-    public void addNewScore(long solverId, int score) {
-        if (solverId == ownerId) {
+    public void addNewScore(Long solverId, int score) {
+        if (solverId != null && solverId == ownerId) {
             return;
         }
 

--- a/src/main/java/com/nexters/keyme/statistics/domain/repository/StatisticRepository.java
+++ b/src/main/java/com/nexters/keyme/statistics/domain/repository/StatisticRepository.java
@@ -4,6 +4,7 @@ import com.nexters.keyme.statistics.domain.model.Statistic;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import javax.persistence.LockModeType;
 import java.util.List;
@@ -13,15 +14,18 @@ public interface StatisticRepository extends JpaRepository<Statistic, Long> {
 
     @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT st FROM Statistic st WHERE st.ownerId = :ownerId AND st.questionId = :questionId")
-    Optional<Statistic> findByOwnerIdAndQuestionIdWithLock(long ownerId, long questionId);
+    Optional<Statistic> findByOwnerIdAndQuestionIdWithLock(@Param(value = "ownerId") long ownerId, @Param(value = "questionId") long questionId);
 
     @Query(value = "SELECT * FROM statistic st WHERE st.owner_id = :memberId ORDER BY st.match_rate LIMIT 5", nativeQuery = true)
-    List<Statistic> findByMemberIdSortByMatchRateAsc(long memberId);
+    List<Statistic> findByMemberIdSortByMatchRateAsc(@Param(value = "memberId") long memberId);
 
     @Query(value = "SELECT * FROM statistic st WHERE st.owner_id = :memberId ORDER BY st.match_rate DESC LIMIT 5", nativeQuery = true)
-    List<Statistic> findByMemberIdSortByMatchRateDesc(long memberId);
+    List<Statistic> findByMemberIdSortByMatchRateDesc(@Param(value = "memberId") long memberId);
 
     @Query(value = "SELECT * FROM statistic st WHERE (st.solver_avg_score < :cursorScore OR st.solver_avg_score = :cursorScore AND st.id > :cursor) AND st.id NOT IN :exceptIds ORDER BY st.match_rate DESC, st.id LIMIT :limit", nativeQuery = true)
-    List<Statistic> findExceptIdsSortByAvgScore(List<Long> exceptIds, long cursor, double cursorScore, int limit);
+    List<Statistic> findExceptIdsSortByAvgScore(@Param(value = "exceptIds") List<Long> exceptIds,
+                                                @Param(value = "cursor") long cursor,
+                                                @Param(value = "cursorScore") double cursorScore,
+                                                @Param(value = "limit") int limit);
 
 }


### PR DESCRIPTION
### Issue
- close #86 

### Summary
- 테스트 결과 제출과 함께 비동기로 멤버 통계정보 추가 시, 널포인터 예외가 발생하는 버그를 수정했습니다.

### Description
- Statistic 도메인의 addNewScore 인자로 들어오는 solverId가 원시 타입이어서 null을 허용하지 않아 생긴 문제입니다.
- 해당 인자를 Wrapper 타입으로 바꾸고, 메서드 내 조건문에서 널 검증 관련 코드를 추가했습니다.