### PR TITLE
S3ImageUploader 예외 변환 시 원 예외 스택트레이스 출력하도록 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
+++ b/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -36,7 +37,7 @@ public class S3ImageUploader implements ImageUploader {
             originalUrl = uploadToS3AndGetUrl(image.getInputStream(), extension);
             thumbnailUrl = uploadToS3AndGetUrl(resizeForThumbnail(image), extension);
         } catch (IOException e) {
-            log.error(e.getMessage());
+            log.error(Arrays.toString(e.getStackTrace()));
             throw new FileUploadFailedException();
         }
 


### PR DESCRIPTION
### Issue
- #103 

### Summary
- S3ImageUploader에서 FileNotFoundException으로 변환 시 원 예외의 스택트레이스도 출력하도록 변경합니다.

### Description
- 예외가 변환되는 과정에서 원 예외의 스택트레이스가 사라져 원인 파악에 어려움이 있습니다. 추후 예외 변환 시에는 이러한 점을 고려해야 할 듯합니다!