### PR TITLE
S3 이미지 업로더에서 섬네일 파일을 명시적으로 생성하도록 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
+++ b/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
@@ -47,6 +47,7 @@ public class S3ImageUploader implements ImageUploader {
     private File resizeForThumbnail(MultipartFile image) throws IOException {
         String extension = extractExtension(image);
         File thumbnail = new File(tempImagePath + UUID.randomUUID() + "." + extension);
+        thumbnail.createNewFile();
 
         Thumbnails.of(image.getInputStream())
             .size(700, 400)


### PR DESCRIPTION
### Issue
- #103 

### Summary
- 로컬 환경과의 차이로 서버에서는 Thumbnailator 라이브러리가 섬네일 파일 경로에 파일이 존재할 때에만 섬네일 파일로 전환하는 것으로 추정됩니다.
- 보다 정확한 원인 파악은 추후 내부 구현 등을 살펴보아야 할 듯합니다.

### Description