### PR TITLE
S3ImageUploader 섬네일 리사이즈 시 createNewFile() 삭제

### DIFF
--- a/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
+++ b/src/main/java/com/nexters/keyme/member/infrastructure/S3ImageUploader.java
@@ -49,7 +49,6 @@ public class S3ImageUploader implements ImageUploader {
     private File resizeForThumbnail(MultipartFile image) throws IOException {
         String extension = extractExtension(image);
         File thumbnail = new File(tempImagePath + UUID.randomUUID() + "." + extension);
-        thumbnail.createNewFile();
 
         Thumbnails.of(image.getInputStream())
             .size(700, 400)


### PR DESCRIPTION
### Issue
- #103 

### Summary
- 이미지 IOException은 도커 경로 문제로 발생한 오류로 확인되었고, 디버깅 과정에서 추가했던 createNewFile() 메서드는 삭제합니다.

### Description