### PR TITLE
요청 로그 Request Body 누락 수정

### DIFF
--- a/src/main/java/com/nexters/keyme/common/filter/LoggingFilter.java
+++ b/src/main/java/com/nexters/keyme/common/filter/LoggingFilter.java
@@ -66,15 +66,15 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private String getBodyString(HttpServletRequest request) throws UnsupportedEncodingException {
         String method = request.getMethod();
-        if (!(method == HttpMethod.POST.name() ||
-                method == HttpMethod.PUT.name() ||
-                method == HttpMethod.PATCH.name())
+        if (!(method.equals(HttpMethod.POST.name()) ||
+                method.equals(HttpMethod.PUT.name()) ||
+                method.equals(HttpMethod.PATCH.name()))
         ) return "";
 
         if (request instanceof ContentCachingRequestWrapper) {
             ContentCachingRequestWrapper cachingRequestWrapper = (ContentCachingRequestWrapper) request;
             byte[] content = cachingRequestWrapper.getContentAsByteArray();
-            return new String(content, 0, 1024, cachingRequestWrapper.getCharacterEncoding());
+            return new String(content, cachingRequestWrapper.getCharacterEncoding());
         }
 
         return "";


### PR DESCRIPTION
### Issue
- close #116 

### Summary
- 요청 로그에서 Request Body의 내용이 누락되는 현상을 수정했습니다.

### Description
- 메서드 String 비교를 ==에서 equals()로 변경
- byte[] -> String 변환 시 offset, length 관련 outOfBounds 에러 발생하여 String(bytes, charsetName) 생성자로 변경
