### PR TITLE
푸시알림 발송 관련 오류 수정

### DIFF
--- a/src/main/java/com/nexters/keyme/notification/dto/UserNotificationRequest.java
+++ b/src/main/java/com/nexters/keyme/notification/dto/UserNotificationRequest.java
@@ -18,6 +18,6 @@ public class UserNotificationRequest {
     private final Map<String, String> data;
 
     public Map<String, String> getData() {
-        return new HashMap<>(data);
+        return data == null ? new HashMap<>() : new HashMap<>(data);
     }
 }

--- a/src/main/java/com/nexters/keyme/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/notification/service/NotificationServiceImpl.java
@@ -23,9 +23,10 @@ public class NotificationServiceImpl implements NotificationService {
     @Async("NotificationThreadPool")
     public CompletableFuture<Boolean> sendByUsers(UserNotificationRequest request) {
         List<String> tokens = new ArrayList<>();
+        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberIds(request.getUserIds());
 
-        for (MemberDevice device : memberDeviceRepository.findAllByMemberIds(request.getUserIds())) {
-            tokens.add(String.valueOf(device.getId()));
+        for (MemberDevice device : devices) {
+            tokens.add(String.valueOf(device.getToken()));
         }
 
         notificationSender.sendByTokens(tokens, request.getTitle(), request.getBody(), request.getData());


### PR DESCRIPTION
### Issue
- close #118

### Summary
- FCM 푸시알림 발송 관련 코드의 에러를 수정했습니다.

### Description
- 알림 서비스에서 MemberDevice의 토큰 값을 가져올 때 device.getToken()이 아닌 device.getId()를 호출하는 부분 수정
- UserNotificationRequest 요청 객체에서 data가 null일 경우 getData() 내부 로직에서 NPE 발생. 빈 해시맵을 리턴하도록 수정.