### PR TITLE
FCM 메시지 발송 및 발송 실패 시 로깅 추가

### DIFF
--- a/src/test/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepositoryTest.java
@@ -8,11 +8,9 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
 
 @RepositoryTest
 @Import(QueryDslConfig.class)
@@ -28,5 +26,14 @@ class MemberDeviceRepositoryTest {
 
         Assertions.assertThat(device.getId()).isEqualTo(1L);
         Assertions.assertThat(device.getToken()).isEqualTo("token1");
+    }
+
+    @Test
+    @DisplayName("멤버 id와 토큰으로 Device 조회")
+    void findByMemberIdsTest() {
+        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberIds(List.of(2L));
+
+        Assertions.assertThat(devices.size()).isEqualTo(3);
+        Assertions.assertThat(devices.get(0).getToken()).isEqualTo("token1");
     }
 }


### PR DESCRIPTION
### Issue
- #118 

### Summary
- FCM 메시지 발송 시 로깅을 추가했습니다.

### Description
- 발송 요청 전 발송하려는 token 정보를 로깅합니다.
- 발송 이후 실패할 경우, FCM에서 리턴되는 batchResponse 내부의 Exception 정보를 로깅하여 원인을 추적할 수 있도록 합니다.