### PR TITLE
FCM 푸시 관련 임시 로그 삭제, 본인 테스트 풀이 시 알림 미발송 로직 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepository.java
+++ b/src/main/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepository.java
@@ -14,4 +14,7 @@ public interface MemberDeviceRepository extends JpaRepository<MemberDevice, Long
 
     @Query("SELECT md FROM MemberDevice md WHERE md.member.id IN :memberIds")
     List<MemberDevice> findAllByMemberIds(@Param(value = "memberIds") List<Long> memberIds);
+
+    @Query("SELECT md FROM MemberDevice md WHERE md.member.id = :memberId")
+    List<MemberDevice> findAllByMemberId(@Param(value = "memberId") Long memberId);
 }

--- a/src/main/java/com/nexters/keyme/notification/dto/UserNotificationRequest.java
+++ b/src/main/java/com/nexters/keyme/notification/dto/UserNotificationRequest.java
@@ -3,14 +3,13 @@ package com.nexters.keyme.notification.dto;
 import lombok.*;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @Builder
 @Getter
 @RequiredArgsConstructor
 public class UserNotificationRequest {
-    private final List<Long> userIds;
+    private final Long userId;
     private final String title;
     private final String body;
     @Singular("info")

--- a/src/main/java/com/nexters/keyme/notification/handler/NotificationRequestHandler.java
+++ b/src/main/java/com/nexters/keyme/notification/handler/NotificationRequestHandler.java
@@ -15,7 +15,7 @@ public class NotificationRequestHandler {
 
     @EventListener
     public void handleUserNotificationRequest(UserNotificationRequest request) {
-        notificationService.sendByUsers(request);
+        notificationService.sendByUser(request);
     }
 
     @EventListener

--- a/src/main/java/com/nexters/keyme/notification/service/NotificationService.java
+++ b/src/main/java/com/nexters/keyme/notification/service/NotificationService.java
@@ -6,7 +6,7 @@ import com.nexters.keyme.notification.dto.UserNotificationRequest;
 import java.util.concurrent.CompletableFuture;
 
 public interface NotificationService {
-    CompletableFuture<Boolean> sendByUsers(UserNotificationRequest request);
+    CompletableFuture<Boolean> sendByUser(UserNotificationRequest request);
 
     void sendByTopics(TopicNotificationRequest request);
 }

--- a/src/main/java/com/nexters/keyme/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/notification/service/NotificationServiceImpl.java
@@ -24,16 +24,12 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Async
     public CompletableFuture<Boolean> sendByUsers(UserNotificationRequest request) {
-        log.info("start notificationService!");
         List<String> tokens = new ArrayList<>();
         List<MemberDevice> devices = memberDeviceRepository.findAllByMemberIds(request.getUserIds());
 
         for (MemberDevice device : devices) {
             tokens.add(String.valueOf(device.getToken()));
-            log.info("token: {}", device.getToken());
         }
-
-
 
         notificationSender.sendByTokens(tokens, request.getTitle(), request.getBody(), request.getData());
         return CompletableFuture.completedFuture(Boolean.TRUE);

--- a/src/main/java/com/nexters/keyme/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/notification/service/NotificationServiceImpl.java
@@ -23,9 +23,9 @@ public class NotificationServiceImpl implements NotificationService {
     private final MemberDeviceRepository memberDeviceRepository;
 
     @Async
-    public CompletableFuture<Boolean> sendByUsers(UserNotificationRequest request) {
+    public CompletableFuture<Boolean> sendByUser(UserNotificationRequest request) {
         List<String> tokens = new ArrayList<>();
-        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberIds(request.getUserIds());
+        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberId(request.getUserId());
 
         for (MemberDevice device : devices) {
             tokens.add(String.valueOf(device.getToken()));

--- a/src/main/java/com/nexters/keyme/test/application/TestServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/test/application/TestServiceImpl.java
@@ -37,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -150,7 +151,7 @@ public class TestServiceImpl implements TestService {
         // test 존재확인, owner가 호출자와 맞는지 확인
         testRepository.findById(testId)
                 .map(test -> test.getMember().getId())
-                .filter(testOwnerId -> testOwnerId == memberId)
+                .filter(testOwnerId -> Objects.equals(testOwnerId, memberId))
                 .orElseThrow(ResourceNotFoundException::new);
 
         // FIXME : 두 통계 쿼리 병렬 수행 필요
@@ -194,7 +195,7 @@ public class TestServiceImpl implements TestService {
         }
 
         // TODO : 일치율 계산 로직 추가 및 domain service로 분리
-        Float matchRate = test.getMember().getId() == solverId ? 100f : 0f;
+        Float matchRate = Objects.equals(test.getMember().getId(), solverId) ? 100f : 0f;
 
         // FIXME : Create TestResult 로직 분리
         TestResult testResult = TestResult.builder()
@@ -216,7 +217,7 @@ public class TestServiceImpl implements TestService {
         questionSolvedRepository.saveAll(questionSolvedList);
 
         eventPublisher.publishEvent(new AddStatisticEvent(test.getMember().getId(), solverId, questionSolvedList));
-        eventPublisher.publishEvent(new SendNotificationEvent(List.of(test.getMember().getId())));
+        eventPublisher.publishEvent(new SendNotificationEvent(test.getMember().getId(), solverId));
 
         String resultCode = null;
         if (solverId == null) {

--- a/src/main/java/com/nexters/keyme/test/events/SendNotificationEvent.java
+++ b/src/main/java/com/nexters/keyme/test/events/SendNotificationEvent.java
@@ -4,11 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @AllArgsConstructor
 @Builder
 @Getter
 public class SendNotificationEvent {
-    private List<Long> userIds;
+    private Long ownerId;
+    private Long solverId;
 }

--- a/src/main/java/com/nexters/keyme/test/events/TestEventHandler.java
+++ b/src/main/java/com/nexters/keyme/test/events/TestEventHandler.java
@@ -29,13 +29,8 @@ public class TestEventHandler {
 
     @EventListener
     public void handleSendNotificationEvent(SendNotificationEvent event) {
-        log.info("notification logging test");
-        try {
-            UserNotificationRequest request = new UserNotificationRequest(event.getUserIds(), "내 문제를 푼 친구가 있어요!", "지금 Keyme에서 확인해보세요.", null);
-            notificationService.sendByUsers(request);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-        }
+        UserNotificationRequest request = new UserNotificationRequest(event.getUserIds(), "내 문제를 푼 친구가 있어요!", "지금 Keyme에서 확인해보세요.", null);
+        notificationService.sendByUsers(request);
     }
 
 }

--- a/src/main/java/com/nexters/keyme/test/events/TestEventHandler.java
+++ b/src/main/java/com/nexters/keyme/test/events/TestEventHandler.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @RequiredArgsConstructor
 @Component
 @Slf4j
@@ -29,8 +31,15 @@ public class TestEventHandler {
 
     @EventListener
     public void handleSendNotificationEvent(SendNotificationEvent event) {
-        UserNotificationRequest request = new UserNotificationRequest(event.getUserIds(), "내 문제를 푼 친구가 있어요!", "지금 Keyme에서 확인해보세요.", null);
-        notificationService.sendByUsers(request);
+        Long solverId = event.getSolverId();
+        Long ownerId = event.getOwnerId();
+
+        if (Objects.equals(ownerId, solverId)) {
+            return;
+        }
+
+        UserNotificationRequest request = new UserNotificationRequest(event.getOwnerId(), "내 문제를 푼 친구가 있어요!", "지금 Keyme에서 확인해보세요.", null);
+        notificationService.sendByUser(request);
     }
 
 }

--- a/src/test/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.nexters.keyme.member.domain.repository;
 
-import com.nexters.keyme.common.config.QueryDslConfig;
 import com.nexters.keyme.common.exceptions.ResourceNotFoundException;
 import com.nexters.keyme.member.domain.model.MemberDevice;
 import com.nexters.keyme.test.annotation.RepositoryTest;
@@ -8,12 +7,10 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
 @RepositoryTest
-@Import(QueryDslConfig.class)
 class MemberDeviceRepositoryTest {
     @Autowired
     private MemberDeviceRepository memberDeviceRepository;

--- a/src/test/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/member/domain/repository/MemberDeviceRepositoryTest.java
@@ -29,9 +29,18 @@ class MemberDeviceRepositoryTest {
     }
 
     @Test
-    @DisplayName("멤버 id와 토큰으로 Device 조회")
-    void findByMemberIdsTest() {
-        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberIds(List.of(2L));
+    @DisplayName("멤버 id 리스트로 Device 조회")
+    void findAllByMemberIdsTest() {
+        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberIds(List.of(1L));
+
+        Assertions.assertThat(devices.size()).isEqualTo(3);
+        Assertions.assertThat(devices.get(0).getToken()).isEqualTo("token1");
+    }
+
+    @Test
+    @DisplayName("멤버 id로 Device 조회")
+    void findAllByMemberIdTest() {
+        List<MemberDevice> devices = memberDeviceRepository.findAllByMemberId(1L);
 
         Assertions.assertThat(devices.size()).isEqualTo(3);
         Assertions.assertThat(devices.get(0).getToken()).isEqualTo("token1");

--- a/src/test/java/com/nexters/keyme/member/domain/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/member/domain/repository/MemberRepositoryTest.java
@@ -2,19 +2,15 @@ package com.nexters.keyme.member.domain.repository;
 
 import com.nexters.keyme.common.exceptions.ResourceNotFoundException;
 import com.nexters.keyme.member.domain.model.MemberEntity;
+import com.nexters.keyme.test.annotation.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DataJpaTest
-@AutoConfigureTestDatabase
-@ActiveProfiles("test")
+@RepositoryTest
 class MemberRepositoryTest {
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/com/nexters/keyme/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/nexters/keyme/notification/service/NotificationServiceTest.java
@@ -2,13 +2,10 @@ package com.nexters.keyme.notification.service;
 
 import com.nexters.keyme.notification.dto.UserNotificationRequest;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -24,11 +21,11 @@ class NotificationServiceTest {
         UserNotificationRequest request = UserNotificationRequest.builder()
                 .title("title")
                 .body("body")
-                .userIds(List.of(1L))
+                .userId(1L)
                 .info("infoKey", "value")
                 .build();
 
-        CompletableFuture<Boolean> response = notificationService.sendByUsers(request);
+        CompletableFuture<Boolean> response = notificationService.sendByUser(request);
 
         Assertions.assertThat(response.get()).isTrue();
     }
@@ -39,11 +36,11 @@ class NotificationServiceTest {
         UserNotificationRequest request = UserNotificationRequest.builder()
                 .title("title")
                 .body("body")
-                .userIds(List.of(10L))
+                .userId(1L)
                 .info("infoKey", "value")
                 .build();
 
-        CompletableFuture<Boolean> response = notificationService.sendByUsers(request);
+        CompletableFuture<Boolean> response = notificationService.sendByUser(request);
 
         Assertions.assertThat(response.get()).isTrue();
     }

--- a/src/test/java/com/nexters/keyme/question/domain/repository/QuestionSolvedRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/question/domain/repository/QuestionSolvedRepositoryTest.java
@@ -1,21 +1,15 @@
 package com.nexters.keyme.question.domain.repository;
 
-import com.nexters.keyme.common.config.QueryDslConfig;
 import com.nexters.keyme.common.dto.internal.PageInfo;
 import com.nexters.keyme.question.domain.enums.QuestionCategoryType;
 import com.nexters.keyme.question.domain.internaldto.QuestionStatisticInfo;
 import com.nexters.keyme.question.domain.model.QuestionSolved;
-import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 import com.nexters.keyme.test.annotation.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 
 @RepositoryTest
-@Import(QueryDslConfig.class)
 class QuestionSolvedRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
@@ -2,20 +2,16 @@ package com.nexters.keyme.statistics.domain.repository;
 
 import com.nexters.keyme.common.exceptions.ResourceNotFoundException;
 import com.nexters.keyme.statistics.domain.model.Statistic;
+import com.nexters.keyme.test.annotation.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@AutoConfigureTestDatabase
-@ActiveProfiles("test")
+@RepositoryTest
 class StatisticRepositoryTest {
     @Autowired
     private StatisticRepository statisticRepository;

--- a/src/test/java/com/nexters/keyme/test/annotation/RepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/test/annotation/RepositoryTest.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.test.annotation;
 
+import com.nexters.keyme.common.config.QueryDslConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
@@ -13,5 +14,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(QueryDslConfig.class)
 public @interface RepositoryTest {
 }


### PR DESCRIPTION
### Issue
- #118 

### Summary
- 배포 환경에서 FCM 오류 원인 확인하여 임시 로그를 삭제했습니다.
- 본인 테스트 풀이 시 알림 미발송 로직을 추가했습니다.

### Description
**FCM 발송 오류 원인 파악**
- FCM 발송 버그는 운영 환경에서의 DB 스키마가 JPA 형식과 맞지 않은 상태로 유지되고 있어 발생한 것으로 확인했습니다.
- JPA 상으로 `@id`의 컬럼명이 `member_device_id`으로 명시되어 있는데, 운영 DB 상으로는 `id` 컬럼이 PK로 되어 있고, `member_device_id` 컬럼이 공존하는 상황이었습니다. 현재 EC2에서는 ddl-auto가 update로 되어 있어 스키마 변경 도중 `member_device_id` 컬럼만 추가된 것으로 보입니다.
- 토큰 등록 API에서는 ID 증가방식을 `IDENTITY`를 사용하기 때문에 DB 상 PK인 `id`에 값이 들어갔고 `member_device_id`는 null인 상태여서 조회 쿼리 시 명시된 `@id` 컬럼이 null이므로 엔티티를 repository에서 제대로 가져오지 못한 것으로 보입니다. 스키마 변경 시 업데이트 동작 방식 및 `@id` 컬럼의 동작방식에 대해서는 조금 더 확인해 볼 예정입니다.
- 실서비스 배포 후에는 JPA의 자동 스키마 생성이 아닌 자체 DDL로 관리해야 할 듯합니다.

**NotificationService 인터페이스 수정 및 본인 테스트 제출 시 알림 미발송**
- 현재 복수의 유저에게 알림을 보내는 형태로 짜여 있는 인터페이스를 단일 유저에게 보내는 것으로 변경했습니다. notification 도메인은 아직 구조가 제대로 잡힌 상황은 아니어서, 추후 알림 쿼리 등을 구현하면서 구조 개선 및 리팩토링 예정입니다.
- Test 도메인의 EventHandler에서 본인의 테스트를 풀이했을 때에는 알림 로직을 호출하지 않도록 변경했습니다.

**Long 비교 메서드 수정 및 `@RepositoryTest` 애노테이션 수정**
- 코드 변경 후 테스트 과정에서 Long 객체를 ==으로 비교할 시 constant pool 이외의 값은 제대로 동작하지 않는다는 점을 알게 되어 현재 notification 관련 코드와 testResultService 부분의 해당 코드들을 Objects.equals로 변경해 두었습니다. 추후 관련 코드들의 수정이 필요해 보입니다.
- `@RepositoryTest`에 QueryDsl 설정 클래스 import 애노테이션을 포함시켰습니다.