### PR TITLE
통계 요청 시 타입 파라미터 누락 수정, 문제별 소유자 점수 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -3,7 +3,6 @@ package com.nexters.keyme.statistics.application;
 import com.nexters.keyme.common.exceptions.ResourceNotFoundException;
 import com.nexters.keyme.question.domain.model.Question;
 import com.nexters.keyme.question.domain.repository.QuestionRepository;
-import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 import com.nexters.keyme.statistics.application.dto.ScoreInfo;
 import com.nexters.keyme.statistics.domain.internaldto.CoordinateInfo;
 import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
@@ -15,6 +14,7 @@ import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.response.CoordinateResponse;
 import com.nexters.keyme.statistics.presentation.dto.response.MemberStatisticResponse;
+import com.nexters.keyme.statistics.presentation.dto.response.StatisticQuestionResponse;
 import com.nexters.keyme.statistics.presentation.dto.response.StatisticResultResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -86,7 +86,7 @@ public class StatisticServiceImpl implements StatisticService {
             Question question = questionRepository.findById(statistic.getQuestionId())
                     .orElseThrow(ResourceNotFoundException::new);
 
-            results.add(new StatisticResultResponse(new QuestionStatisticResponse(question, statistic.getSolverAvgScore()), new CoordinateResponse(coordinateInfo)));
+            results.add(new StatisticResultResponse(new StatisticQuestionResponse(question, statistic.getOwnerScore(), statistic.getSolverAvgScore()), new CoordinateResponse(coordinateInfo)));
         }
 
         return new MemberStatisticResponse(memberId, results);

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/request/StatisticRequest.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/request/StatisticRequest.java
@@ -5,8 +5,10 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class StatisticRequest {

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/response/StatisticQuestionResponse.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/response/StatisticQuestionResponse.java
@@ -1,0 +1,36 @@
+package com.nexters.keyme.statistics.presentation.dto.response;
+
+import com.nexters.keyme.question.domain.internaldto.QuestionStatisticInfo;
+import com.nexters.keyme.question.domain.model.Question;
+import com.nexters.keyme.question.presentation.dto.response.QuestionCategoryResponse;
+import com.nexters.keyme.question.presentation.dto.response.QuestionResponse;
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@ApiModel(description = "Question 통계 정보")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class StatisticQuestionResponse extends QuestionResponse {
+    private double avgScore;
+    private int ownerScore;
+
+    public StatisticQuestionResponse(QuestionStatisticInfo info) {
+        super(info.getQuestionId(), info.getTitle(), info.getKeyword(), new QuestionCategoryResponse(info.getCategoryName()));
+        this.avgScore = info.getAvgScore();
+    }
+
+    // 아무도 푼 사람이 없을때 통계값
+    public StatisticQuestionResponse(Question question) {
+        super(question);
+        this.avgScore = 0.0;
+    }
+
+    public StatisticQuestionResponse(Question question, int ownerScore, double averageScore) {
+        super(question);
+        this.ownerScore = ownerScore;
+        this.avgScore = averageScore;
+    }
+}

--- a/src/main/java/com/nexters/keyme/statistics/presentation/dto/response/StatisticResultResponse.java
+++ b/src/main/java/com/nexters/keyme/statistics/presentation/dto/response/StatisticResultResponse.java
@@ -1,6 +1,5 @@
 package com.nexters.keyme.statistics.presentation.dto.response;
 
-import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StatisticResultResponse {
     @ApiModelProperty(value="문제별 통계 정보")
-    private final QuestionStatisticResponse questionStatistic;
+    private final StatisticQuestionResponse statisticQuestion;
     @ApiModelProperty(value="포도송이 좌표값 정보")
     private final CoordinateResponse coordinate;
 }

--- a/src/test/java/com/nexters/keyme/statistics/application/StatisticServiceTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/application/StatisticServiceTest.java
@@ -1,14 +1,16 @@
 package com.nexters.keyme.statistics.application;
 
 import com.nexters.keyme.question.presentation.dto.response.QuestionCategoryResponse;
-import com.nexters.keyme.question.presentation.dto.response.QuestionStatisticResponse;
 import com.nexters.keyme.statistics.application.dto.ScoreInfo;
 import com.nexters.keyme.statistics.domain.internaldto.StatisticInfo;
 import com.nexters.keyme.statistics.domain.model.Statistic;
 import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticRequest;
 import com.nexters.keyme.statistics.presentation.dto.AdditionalStatisticResponse;
 import com.nexters.keyme.statistics.presentation.dto.request.StatisticRequest;
-import com.nexters.keyme.statistics.presentation.dto.response.*;
+import com.nexters.keyme.statistics.presentation.dto.response.CoordinateResponse;
+import com.nexters.keyme.statistics.presentation.dto.response.MemberStatisticResponse;
+import com.nexters.keyme.statistics.presentation.dto.response.StatisticQuestionResponse;
+import com.nexters.keyme.statistics.presentation.dto.response.StatisticResultResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,7 +60,7 @@ class StatisticServiceTest {
 
         StatisticResultResponse firstResult = results.get(0);
 
-        QuestionStatisticResponse question = firstResult.getQuestionStatistic();
+        StatisticQuestionResponse question = firstResult.getStatisticQuestion();
         assertThat(question.getQuestionId()).isEqualTo(1L);
         assertThat(question.getAvgScore()).isEqualTo(1L);
         assertThat(question.getTitle()).isEqualTo("새로운 사람들과 대화하는 것을 즐기시겠군요?");


### PR DESCRIPTION
### Issue
- #133 
- #134 

### Summary
- 통계 조회 요청 시 Request DTO에 Setter를 추가하여 type 파라미터가 매핑되도록 수정했습니다.
- 통계 조회 요청 시 문제별 소유자 점수를 추가했습니다.

### Description