### PR TITLE
원 크기 기준을 일치율에서 문제 푼 유저들의 평균점수로 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/statistics/infrastcurture/PythonCoordinateConversionService.java
+++ b/src/main/java/com/nexters/keyme/statistics/infrastcurture/PythonCoordinateConversionService.java
@@ -22,7 +22,7 @@ public class PythonCoordinateConversionService implements CoordinateConversionSe
     @Override
     public List<CoordinateInfo> convertFrom(List<Statistic> statistics) {
         List<Double> collect = statistics.stream()
-                .map((s) -> Double.valueOf(s.getMatchRate()))
+                .map(Statistic::getSolverAvgScore)
                 .collect(Collectors.toList());
 
         CoordinateResponse response = WebClient.create().post()
@@ -36,7 +36,7 @@ public class PythonCoordinateConversionService implements CoordinateConversionSe
                 .bodyToFlux(CoordinateResponse.class)
                 .toStream()
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException());
+                .orElseThrow(RuntimeException::new);
 
         return response.getCircles().stream()
                 .map((circle) -> new CoordinateInfo(circle.getX(), circle.getY(), circle.getR()))


### PR DESCRIPTION
### Issue
- #136

### Summary
- 원 크기 기준을 일치율에서 문제 푼 유저들의 평균점수로 변경했습니다.
- 파이썬 서버에서는 평균점수의 제곱값을 기준으로 원 크기를 계산하도록 로직을 수정했습니다.

### Description