### PR TITLE
통계 조회 쿼리 풀이자 점수별로 오름차순 정렬하도록 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/statistics/application/StatisticServiceImpl.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -75,6 +76,8 @@ public class StatisticServiceImpl implements StatisticService {
             throw new ResourceNotFoundException();
         }
 
+        statistics.sort(getStatisticComparator());
+
         List<CoordinateInfo> coordinates = conversionService.convertFrom(statistics);
 
         List<StatisticResultResponse> results = new ArrayList<>();
@@ -90,6 +93,17 @@ public class StatisticServiceImpl implements StatisticService {
         }
 
         return new MemberStatisticResponse(memberId, results);
+    }
+
+    private static Comparator<Statistic> getStatisticComparator() {
+        return (s1, s2) -> {
+            if (s1.getSolverAvgScore() > s2.getSolverAvgScore()) {
+                return 1;
+            } else if (s1.getSolverAvgScore() < s2.getSolverAvgScore()) {
+                return -1;
+            }
+            return 0;
+        };
     }
 
     private boolean checkStatisticExists(List<Statistic> statistics) {


### PR DESCRIPTION
### Issue
- #136 

### Summary
- Circlify 라이브러리 결과값이 자동으로 오름차순 정렬되므로, 입력값을 원 생성 기준인 풀이자 점수의 오름차순으로 정렬해 넘기도록 변경했습니다.

### Description
- 변경 내용을 자세하게 작성해 주세요