### PR TITLE
멤버 정보 변경 시 닉네임 변경여부 확인, 필드 Not null 제약조건 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/member/application/MemberServiceImpl.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.nexters.keyme.global.common.constant.ConstantString.DEFAULT_IMAGE_URL;
@@ -95,14 +96,22 @@ public class MemberServiceImpl implements MemberService {
                 .thumbnailImage(request.getProfileThumbnail())
                 .build();
 
-        nicknameValidator.validateNickname(modificationInfo.getNickname());
-
         MemberEntity member = memberRepository.findById(userInfo.getMemberId())
                 .orElseThrow(NotFoundMemberException::new);
+
+        if (isNicknameChanged(modificationInfo, member)) {
+            nicknameValidator.validateNickname(modificationInfo.getNickname());
+        }
+
         member.modifyMemberInfo(modificationInfo);
 
         return new MemberResponse(member);
     }
+
+    private boolean isNicknameChanged(MemberModificationInfo modificationInfo, MemberEntity member) {
+        return !Objects.equals(member.getNickname(), modificationInfo.getNickname());
+    }
+
 
     @Override
     public ImageResponse uploadImage(MultipartFile image) {

--- a/src/main/java/com/nexters/keyme/domain/member/dto/request/MemberModificationRequest.java
+++ b/src/main/java/com/nexters/keyme/domain/member/dto/request/MemberModificationRequest.java
@@ -6,15 +6,20 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 public class MemberModificationRequest {
     @ApiModelProperty(value="닉네임", example = "키미")
+    @NotNull(message = "닉네임을 입력해주세요.")
     private String nickname;
     @ApiModelProperty(value="프로필 이미지 URL")
+    @NotNull(message = "프로필 이미지가 유효하지 않습니다.")
     private String profileImage;
     @ApiModelProperty(value="프로필 이미지 섬네일 URL")
+    @NotNull(message = "섬네일 이미지가 유효하지 않습니다.")
     private String profileThumbnail;
 }


### PR DESCRIPTION
### Issue
- close #132 
- close #139 

### Summary
- 멤버 정보 변경 시 닉네임 변경여부를 확인해 변경되지 않았을 경우 닉네임 유효성 검증을 시행하지 않습니다.
- 정보 변경 시 모든 필드에 Not null 제약조건을 추가했습니다.

### Description