### PR TITLE
멤버 성격 더보기 API 응답값 Question Id를 보내도록 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/domain/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/statistics/application/StatisticServiceImpl.java
@@ -131,7 +131,7 @@ public class StatisticServiceImpl implements StatisticService {
                 .map((statistic) -> {
                     Question question = questionRepository.findById(statistic.getQuestionId())
                             .orElseThrow(NotFoundQuestionException::new);
-                    return new AdditionalStatisticResponse(statistic.getId(), question.getKeyword(), question.getCategoryName().getColor(), question.getCategoryName().getImageUrl(), statistic.getSolverAvgScore());
+                    return new AdditionalStatisticResponse(question.getQuestionId(), question.getKeyword(), question.getCategoryName().getColor(), question.getCategoryName().getImageUrl(), statistic.getSolverAvgScore());
                 })
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/nexters/keyme/domain/statistics/dto/response/AdditionalStatisticResponse.java
+++ b/src/main/java/com/nexters/keyme/domain/statistics/dto/response/AdditionalStatisticResponse.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public class AdditionalStatisticResponse {
-    @ApiModelProperty(value="통계 정보 id", example = "1")
-    private final long statisticId;
+    @ApiModelProperty(value="문제 id", example = "1")
+    private final long questionId;
     @ApiModelProperty(value="문제 키워드", example = "소통왕")
     private final String keyword;
     @ApiModelProperty(value="카테고리 색상", example = "FFFFFF")


### PR DESCRIPTION
### Issue
- close #151 

### Summary
- 멤버 성격 더보기 API에서, 응답 list의 각 원소에서 StatisticId -> QuestionId를 보내는 것으로 변경했습니다.

### Description