### PR TITLE
멤버 삭제 API 추가

### DIFF
--- a/src/main/java/com/nexters/keyme/domain/clienttest/presentation/controller/ClientTestController.java
+++ b/src/main/java/com/nexters/keyme/domain/clienttest/presentation/controller/ClientTestController.java
@@ -23,6 +23,7 @@ public class ClientTestController {
     @DeleteMapping("/member")
     @ApiOperation(value = "멤버 정보 삭제")
     @SecurityRequirement(name = SWAGGER_AUTHORIZATION_SCHEME)
+    @Deprecated
     public ResponseEntity<ApiResponse> deleteMember(@RequestUser UserInfo userInfo) {
         clientTestService.clearMember(userInfo.getMemberId());
         return ResponseEntity.ok(new ApiResponse(200, "멤버가 삭제되었습니다.", null));

--- a/src/main/java/com/nexters/keyme/domain/member/application/MemberService.java
+++ b/src/main/java/com/nexters/keyme/domain/member/application/MemberService.java
@@ -1,16 +1,13 @@
 package com.nexters.keyme.domain.member.application;
 
-import com.nexters.keyme.domain.auth.dto.internal.OAuthUserInfo;
-import com.nexters.keyme.global.common.dto.internal.UserInfo;
 import com.nexters.keyme.domain.member.dto.request.AddTokenRequest;
 import com.nexters.keyme.domain.member.dto.request.DeleteTokenRequest;
 import com.nexters.keyme.domain.member.dto.request.MemberModificationRequest;
 import com.nexters.keyme.domain.member.dto.request.NicknameVerificationRequest;
 import com.nexters.keyme.domain.member.dto.response.ImageResponse;
-import com.nexters.keyme.domain.member.dto.response.NicknameVerificationResponse;
 import com.nexters.keyme.domain.member.dto.response.MemberResponse;
-import com.nexters.keyme.domain.member.dto.response.MemberWithTokenResponse;
-import org.springframework.transaction.annotation.Transactional;
+import com.nexters.keyme.domain.member.dto.response.NicknameVerificationResponse;
+import com.nexters.keyme.global.common.dto.internal.UserInfo;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
@@ -21,8 +18,6 @@ public interface MemberService {
   MemberResponse modifyMemberInfo(MemberModificationRequest request, UserInfo userInfo);
 
   ImageResponse uploadImage(MultipartFile image);
-
-  @Transactional
   void registerDeviceToken(long userId, AddTokenRequest request);
 
   void deleteDeviceToken(long memberId, DeleteTokenRequest request);

--- a/src/main/java/com/nexters/keyme/domain/member/application/MemberService.java
+++ b/src/main/java/com/nexters/keyme/domain/member/application/MemberService.java
@@ -21,4 +21,6 @@ public interface MemberService {
   void registerDeviceToken(long userId, AddTokenRequest request);
 
   void deleteDeviceToken(long memberId, DeleteTokenRequest request);
+
+  void deleteMember(long memberId);
 }

--- a/src/main/java/com/nexters/keyme/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/member/application/MemberServiceImpl.java
@@ -1,26 +1,25 @@
 package com.nexters.keyme.domain.member.application;
 
-import com.nexters.keyme.domain.auth.dto.internal.OAuthUserInfo;
+import com.nexters.keyme.domain.member.domain.model.MemberDevice;
+import com.nexters.keyme.domain.member.domain.model.MemberEntity;
+import com.nexters.keyme.domain.member.domain.repository.MemberDeviceRepository;
+import com.nexters.keyme.domain.member.domain.repository.MemberRepository;
 import com.nexters.keyme.domain.member.domain.service.processor.MemberDataProcessor;
-import com.nexters.keyme.domain.member.exceptions.NotFoundMemberException;
-import com.nexters.keyme.global.common.dto.internal.UserInfo;
-import com.nexters.keyme.domain.member.domain.model.*;
+import com.nexters.keyme.domain.member.domain.service.processor.ProfileImageUploader;
+import com.nexters.keyme.domain.member.domain.service.validator.MemberValidator;
+import com.nexters.keyme.domain.member.domain.service.validator.NicknameValidator;
 import com.nexters.keyme.domain.member.dto.internal.ImageInfo;
 import com.nexters.keyme.domain.member.dto.internal.MemberModificationInfo;
 import com.nexters.keyme.domain.member.dto.internal.ValidationInfo;
-import com.nexters.keyme.domain.member.domain.repository.MemberDeviceRepository;
-import com.nexters.keyme.domain.member.domain.repository.MemberOAuthRepository;
-import com.nexters.keyme.domain.member.domain.repository.MemberRepository;
-import com.nexters.keyme.domain.member.domain.service.processor.ProfileImageUploader;
-import com.nexters.keyme.domain.member.domain.service.validator.NicknameValidator;
 import com.nexters.keyme.domain.member.dto.request.AddTokenRequest;
 import com.nexters.keyme.domain.member.dto.request.DeleteTokenRequest;
 import com.nexters.keyme.domain.member.dto.request.MemberModificationRequest;
 import com.nexters.keyme.domain.member.dto.request.NicknameVerificationRequest;
 import com.nexters.keyme.domain.member.dto.response.ImageResponse;
 import com.nexters.keyme.domain.member.dto.response.MemberResponse;
-import com.nexters.keyme.domain.member.dto.response.MemberWithTokenResponse;
 import com.nexters.keyme.domain.member.dto.response.NicknameVerificationResponse;
+import com.nexters.keyme.domain.member.exceptions.NotFoundMemberException;
+import com.nexters.keyme.global.common.dto.internal.UserInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,8 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
-import static com.nexters.keyme.global.common.constant.ConstantString.DEFAULT_IMAGE_URL;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +40,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberDataProcessor memberDataProcessor;
     private final NicknameValidator nicknameValidator;
     private final ProfileImageUploader profileImageUploader;
+    private final MemberValidator memberValidator;
 
     @Override
     @Transactional
@@ -134,5 +132,13 @@ public class MemberServiceImpl implements MemberService {
         if (device.isPresent()) {
             memberDeviceRepository.delete(device.get());
         }
+    }
+
+    @Transactional
+    @Override
+    public void deleteMember(long memberId) {
+        MemberEntity member = memberValidator.validateMember(memberId);
+
+        memberDataProcessor.deleteMember(member);
     }
 }

--- a/src/main/java/com/nexters/keyme/domain/member/application/MemberServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/member/application/MemberServiceImpl.java
@@ -45,8 +45,8 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional
     public MemberResponse getMemberInfo(Long memberId) {
-        MemberEntity member = memberRepository.findById(memberId)
-                .orElseThrow(NotFoundMemberException::new);
+        MemberEntity member = memberValidator.validateMember(memberId);
+
         Boolean isOnboardingClear = memberDataProcessor.checkOnboardingClear(member);
 
         MemberResponse memberResponse = new MemberResponse(member);

--- a/src/main/java/com/nexters/keyme/domain/member/domain/model/MemberEntity.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/model/MemberEntity.java
@@ -37,6 +37,7 @@ public class MemberEntity extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus status;
     private ProfileImage profileImage;
+    private boolean isDeleted;
 
 
     public void setProfileImage(ProfileImage profileImage) {

--- a/src/main/java/com/nexters/keyme/domain/member/domain/model/MemberEntity.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/model/MemberEntity.java
@@ -23,7 +23,7 @@ public class MemberEntity extends BaseTimeEntity {
     private Long id;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @JoinColumn(name="member_oauth_id")
+    @JoinColumn(name = "member_id")
     private List<MemberOAuth> memberOauth;
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name="member_id")

--- a/src/main/java/com/nexters/keyme/domain/member/domain/model/MemberEntity.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/model/MemberEntity.java
@@ -57,4 +57,8 @@ public class MemberEntity extends BaseTimeEntity {
             this.profileImage = new ProfileImage(modificationInfo.getOriginalImage(), modificationInfo.getThumbnailImage());
         }
     }
+
+    public void setDeleted() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/nexters/keyme/domain/member/domain/service/processor/MemberDataProcessor.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/service/processor/MemberDataProcessor.java
@@ -1,13 +1,11 @@
 package com.nexters.keyme.domain.member.domain.service.processor;
 
-import com.nexters.keyme.domain.auth.dto.internal.OAuthUserInfo;
 import com.nexters.keyme.domain.member.domain.model.MemberEntity;
 import com.nexters.keyme.domain.member.domain.model.MemberOAuth;
 import com.nexters.keyme.domain.member.domain.model.MemberOAuthId;
 import com.nexters.keyme.domain.member.domain.model.ProfileImage;
 import com.nexters.keyme.domain.member.domain.repository.MemberOAuthRepository;
 import com.nexters.keyme.domain.member.domain.repository.MemberRepository;
-import com.nexters.keyme.domain.member.dto.response.MemberWithTokenResponse;
 import com.nexters.keyme.domain.test.domain.model.Test;
 import com.nexters.keyme.domain.test.domain.model.TestResult;
 import com.nexters.keyme.domain.test.domain.repository.TestResultRepository;
@@ -18,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.nexters.keyme.global.common.constant.ConstantString.DEFAULT_IMAGE_URL;
@@ -65,5 +64,17 @@ public class MemberDataProcessor {
         TestResult testResult = testResultRepository.findByTestAndSolver(onboardingTest, member).orElse(null);
 
         return testResult != null;
+    }
+
+    @Transactional
+    public MemberEntity deleteMember(MemberEntity member) {
+        member.setDeleted();
+        List<MemberOAuth> oauthList = member.getMemberOauth();
+
+        for (MemberOAuth oauth : oauthList) {
+            memberOAuthRepository.deleteById(oauth.getOauthInfo());
+        }
+
+        return member;
     }
 }

--- a/src/main/java/com/nexters/keyme/domain/member/domain/service/processor/MemberDataProcessor.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/service/processor/MemberDataProcessor.java
@@ -1,9 +1,7 @@
 package com.nexters.keyme.domain.member.domain.service.processor;
 
-import com.nexters.keyme.domain.member.domain.model.MemberEntity;
-import com.nexters.keyme.domain.member.domain.model.MemberOAuth;
-import com.nexters.keyme.domain.member.domain.model.MemberOAuthId;
-import com.nexters.keyme.domain.member.domain.model.ProfileImage;
+import com.nexters.keyme.domain.member.domain.model.*;
+import com.nexters.keyme.domain.member.domain.repository.MemberDeviceRepository;
 import com.nexters.keyme.domain.member.domain.repository.MemberOAuthRepository;
 import com.nexters.keyme.domain.member.domain.repository.MemberRepository;
 import com.nexters.keyme.domain.test.domain.model.Test;
@@ -16,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.nexters.keyme.global.common.constant.ConstantString.DEFAULT_IMAGE_URL;
@@ -27,6 +24,7 @@ import static com.nexters.keyme.global.common.constant.ConstantString.DEFAULT_IM
 public class MemberDataProcessor {
 
     private final MemberOAuthRepository memberOAuthRepository;
+    private final MemberDeviceRepository memberDeviceRepository;
     private final MemberRepository memberRepository;
     private final TestDataProcessor testDataProcessor;
     private final TestResultRepository testResultRepository;
@@ -69,10 +67,13 @@ public class MemberDataProcessor {
     @Transactional
     public MemberEntity deleteMember(MemberEntity member) {
         member.setDeleted();
-        List<MemberOAuth> oauthList = member.getMemberOauth();
 
-        for (MemberOAuth oauth : oauthList) {
+        for (MemberOAuth oauth : member.getMemberOauth()) {
             memberOAuthRepository.deleteById(oauth.getOauthInfo());
+        }
+
+        for (MemberDevice device : member.getMemberDevice()) {
+            memberDeviceRepository.deleteById(device.getId());
         }
 
         return member;

--- a/src/main/java/com/nexters/keyme/domain/member/domain/service/validator/MemberValidator.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/service/validator/MemberValidator.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.domain.member.domain.service.validator;
 
+import com.nexters.keyme.domain.member.exceptions.DeletedMemberException;
 import com.nexters.keyme.domain.member.exceptions.NotFoundMemberException;
 import com.nexters.keyme.domain.member.domain.model.MemberEntity;
 import com.nexters.keyme.domain.member.domain.repository.MemberRepository;
@@ -13,6 +14,12 @@ public class MemberValidator {
     private final MemberRepository memberRepository;
 
     public MemberEntity validateMember(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+        MemberEntity member = memberRepository.findById(memberId).orElseThrow(NotFoundMemberException::new);
+
+        if (member.isDeleted()) {
+            throw new DeletedMemberException();
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/nexters/keyme/domain/member/domain/service/validator/MemberValidator.java
+++ b/src/main/java/com/nexters/keyme/domain/member/domain/service/validator/MemberValidator.java
@@ -20,6 +20,6 @@ public class MemberValidator {
             throw new DeletedMemberException();
         }
 
-        return null;
+        return member;
     }
 }

--- a/src/main/java/com/nexters/keyme/domain/member/exceptions/DeletedMemberException.java
+++ b/src/main/java/com/nexters/keyme/domain/member/exceptions/DeletedMemberException.java
@@ -1,0 +1,11 @@
+package com.nexters.keyme.domain.member.exceptions;
+
+import com.nexters.keyme.domain.member.exceptions.code.MemberErrorCode;
+import com.nexters.keyme.global.common.exceptions.KeymeException;
+import org.springframework.http.HttpStatus;
+
+public class DeletedMemberException extends KeymeException {
+    public DeletedMemberException(HttpStatus httpStatus, String message, int code) {
+        super(HttpStatus.OK, MemberErrorCode.DELETED_MEMBER.getMessage(), MemberErrorCode.DELETED_MEMBER.getCode());
+    }
+}

--- a/src/main/java/com/nexters/keyme/domain/member/exceptions/DeletedMemberException.java
+++ b/src/main/java/com/nexters/keyme/domain/member/exceptions/DeletedMemberException.java
@@ -5,7 +5,7 @@ import com.nexters.keyme.global.common.exceptions.KeymeException;
 import org.springframework.http.HttpStatus;
 
 public class DeletedMemberException extends KeymeException {
-    public DeletedMemberException(HttpStatus httpStatus, String message, int code) {
+    public DeletedMemberException() {
         super(HttpStatus.OK, MemberErrorCode.DELETED_MEMBER.getMessage(), MemberErrorCode.DELETED_MEMBER.getCode());
     }
 }

--- a/src/main/java/com/nexters/keyme/domain/member/exceptions/code/MemberErrorCode.java
+++ b/src/main/java/com/nexters/keyme/domain/member/exceptions/code/MemberErrorCode.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum MemberErrorCode {
     NOT_FOUND_MEMBER(404, "Member를 찾을 수 없습니다."),
     DUPLICATED_NICKNAME(201,"이미 사용 중인 닉네임입니다."),
-    NICKNAME_TOO_LONG(202,"닉네임은 7자 이하여야 합니다.");
+    NICKNAME_TOO_LONG(202,"닉네임은 7자 이하여야 합니다."),
+    DELETED_MEMBER(410, "탈퇴한 회원입니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/nexters/keyme/domain/member/exceptions/code/MemberErrorCode.java
+++ b/src/main/java/com/nexters/keyme/domain/member/exceptions/code/MemberErrorCode.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberErrorCode {
     NOT_FOUND_MEMBER(404, "Member를 찾을 수 없습니다."),
-    DUPLICATED_NICKNAME(200,"이미 사용 중인 닉네임입니다."),
-    NICKNAME_TOO_LONG(200,"닉네임은 7자 이하여야 합니다.");
+    DUPLICATED_NICKNAME(201,"이미 사용 중인 닉네임입니다."),
+    NICKNAME_TOO_LONG(202,"닉네임은 7자 이하여야 합니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/nexters/keyme/domain/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/nexters/keyme/domain/member/presentation/controller/MemberController.java
@@ -72,9 +72,16 @@ public class MemberController {
     }
 
     @DeleteMapping("/devices")
-    @ApiOperation("멤버 FCM 토큰 추가")
+    @ApiOperation("멤버 FCM 토큰 삭제")
     public ResponseEntity<ApiResponse> deleteDeviceToken(@RequestUser UserInfo userInfo, @RequestBody DeleteTokenRequest request) {
         memberService.deleteDeviceToken(userInfo.getMemberId(), request);
+        return ResponseEntity.ok(new ApiResponse<>(200, "SUCCESS", null));
+    }
+
+    @DeleteMapping
+    @ApiOperation("멤버 탈퇴")
+    public ResponseEntity<ApiResponse> deleteDeviceToken(@RequestUser UserInfo userInfo) {
+        memberService.deleteMember(userInfo.getMemberId());
         return ResponseEntity.ok(new ApiResponse<>(200, "SUCCESS", null));
     }
 

--- a/src/main/java/com/nexters/keyme/global/config/NotificationThreadPoolConfig.java
+++ b/src/main/java/com/nexters/keyme/global/config/NotificationThreadPoolConfig.java
@@ -1,4 +1,4 @@
-package com.nexters.keyme.global.common;
+package com.nexters.keyme.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/test/java/com/nexters/keyme/member/application/MemberServiceTest.java
+++ b/src/test/java/com/nexters/keyme/member/application/MemberServiceTest.java
@@ -1,15 +1,16 @@
 package com.nexters.keyme.member.application;
 
+import com.nexters.keyme.domain.member.application.MemberService;
+import com.nexters.keyme.domain.member.domain.model.MemberEntity;
+import com.nexters.keyme.domain.member.domain.repository.MemberRepository;
 import com.nexters.keyme.domain.member.domain.service.validator.MemberValidator;
+import com.nexters.keyme.domain.member.dto.request.MemberModificationRequest;
+import com.nexters.keyme.domain.member.dto.request.NicknameVerificationRequest;
+import com.nexters.keyme.domain.member.dto.response.MemberResponse;
+import com.nexters.keyme.domain.member.dto.response.NicknameVerificationResponse;
 import com.nexters.keyme.domain.member.exceptions.DeletedMemberException;
 import com.nexters.keyme.domain.member.exceptions.NicknameDuplicateException;
 import com.nexters.keyme.global.common.dto.internal.UserInfo;
-import com.nexters.keyme.domain.member.application.MemberService;
-import com.nexters.keyme.domain.member.dto.request.MemberModificationRequest;
-import com.nexters.keyme.domain.member.dto.request.NicknameVerificationRequest;
-import com.nexters.keyme.domain.member.dto.response.NicknameVerificationResponse;
-import com.nexters.keyme.domain.member.dto.response.MemberResponse;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +30,9 @@ public class MemberServiceTest {
 
     @Autowired
     private MemberValidator memberValidator;
+
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Test
     @DisplayName("멤버 정보 가져오기 통합테스트")
@@ -74,8 +78,12 @@ public class MemberServiceTest {
     @Test
     @DisplayName("멤버 삭제 통합테스트")
     void deleteMemberTest() {
+        MemberEntity member = memberValidator.validateMember(3L);
+        assertThat(member.isDeleted()).isFalse();
+
         memberService.deleteMember(3L);
 
-        Assertions.assertThatThrownBy(() -> memberValidator.validateMember(3L)).isInstanceOf(DeletedMemberException.class);
+        assertThat(member.isDeleted()).isTrue();
+        assertThatThrownBy(() -> memberValidator.validateMember(3L)).isInstanceOf(DeletedMemberException.class);
     }
 }

--- a/src/test/java/com/nexters/keyme/member/application/MemberServiceTest.java
+++ b/src/test/java/com/nexters/keyme/member/application/MemberServiceTest.java
@@ -1,5 +1,7 @@
 package com.nexters.keyme.member.application;
 
+import com.nexters.keyme.domain.member.domain.service.validator.MemberValidator;
+import com.nexters.keyme.domain.member.exceptions.DeletedMemberException;
 import com.nexters.keyme.domain.member.exceptions.NicknameDuplicateException;
 import com.nexters.keyme.global.common.dto.internal.UserInfo;
 import com.nexters.keyme.domain.member.application.MemberService;
@@ -7,6 +9,7 @@ import com.nexters.keyme.domain.member.dto.request.MemberModificationRequest;
 import com.nexters.keyme.domain.member.dto.request.NicknameVerificationRequest;
 import com.nexters.keyme.domain.member.dto.response.NicknameVerificationResponse;
 import com.nexters.keyme.domain.member.dto.response.MemberResponse;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,10 +27,8 @@ public class MemberServiceTest {
     @Autowired
     private MemberService memberService;
 
-    @Test
-    void getOrCreateMember() {
-
-    }
+    @Autowired
+    private MemberValidator memberValidator;
 
     @Test
     @DisplayName("멤버 정보 가져오기 통합테스트")
@@ -68,5 +69,13 @@ public class MemberServiceTest {
         assertThat(response.getFriendCode()).isEqualTo("ABCDEFG");
         assertThat(response.getProfileImage()).isEqualTo("newOrg");
         assertThat(response.getProfileThumbnail()).isEqualTo("newThumbnail");
+    }
+
+    @Test
+    @DisplayName("멤버 삭제 통합테스트")
+    void deleteMemberTest() {
+        memberService.deleteMember(3L);
+
+        Assertions.assertThatThrownBy(() -> memberValidator.validateMember(3L)).isInstanceOf(DeletedMemberException.class);
     }
 }

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,11 +1,21 @@
 /*
     Member 추가
 */
-INSERT INTO member (id, status, nickname, friend_code, original_url, thumbnail_url, created_at, updated_at)
+INSERT INTO member (id, status, nickname, friend_code, original_url, thumbnail_url, created_at, updated_at, is_deleted)
 VALUES
-    (1, 'ACTIVE', 'nick', 'ABCDEFG', 'keyme.space/original', 'keyme.space.thumbnail', '2023-08-05T16:07:00', '2023-08-05T16:07:00'),
-    (2, 'ACTIVE', 'james', '1234567', 'keyme.space/original', 'keyme.space.thumbnail', '2023-08-05T16:07:00', '2023-08-05T16:07:00'),
-    (3, 'ACTIVE', 'peter', 'A1B2C3D', 'keyme.space/original', 'keyme.space.thumbnail', '2023-08-05T16:07:00', '2023-08-05T16:07:00');
+    (1, 'ACTIVE', 'nick', 'ABCDEFG', 'keyme.space/original', 'keyme.space.thumbnail', '2023-08-05T16:07:00', '2023-08-05T16:07:00', false),
+    (2, 'ACTIVE', 'james', '1234567', 'keyme.space/original', 'keyme.space.thumbnail', '2023-08-05T16:07:00', '2023-08-05T16:07:00', false),
+    (3, 'ACTIVE', 'peter', 'A1B2C3D', 'keyme.space/original', 'keyme.space.thumbnail', '2023-08-05T16:07:00', '2023-08-05T16:07:00', false);
+
+/*
+    Member Oauth 정보 추가
+*/
+
+INSERT INTO member_oauth (oauth_id, oauth_type, member_id)
+VALUES
+    (1, 'KAKAO', 1),
+    (2, 'APPLE', 2),
+    (3, 'KAKAO', 3);
 
 
 /*


### PR DESCRIPTION
### Issue
- close #154 

### Summary
- 멤버 삭제 API를 추가했습니다.
- 클라이언트 테스트용으로 제공한 멤버 삭제 API를 deprecated 처리했습니다.

### Description
**멤버 삭제 API 구현**
- 일전에 논의한 대로 `is_deleted` 필드를 추가해 soft delete 방식으로 구현했습니다.
- `MemberValidator`에서 삭제된 멤버일 경우 예외를 던지도록 하는 검증을 추가했고, 이후 `MemberOauth` 및 `MemberDevice` 정보는 DB 레코드를 직접 삭제하여 추후 재가입 시 문제가 없도록 했습니다.
- Member 도메인에서 `MemberRepsitory`를 직접 의존하고 있는 코드는 `MemberValidator`로 변경해 멤버 삭제 예외를 던질 수 있도록 변경했습니다.

**클라이언트 테스트 API deprecated 처리**
- 기존에 클라이언트 테스트 용으로 제공했던 멤버 삭제 API 관련 오류는 외래키 제약조건 때문에 발생하는 것으로 보입니다.
- 실제 member의 PK를 여러 테이블에서 참조하고 있어서, jdbcTemplate 등을 이용해 로우하게 연관된 모든 레코드를 삭제하는 방식도 고려했는데요. 우선 현재 구현된 멤버 탈퇴 API에서 삭제 시 oauth 정보를 삭제하여 재가입이 가능하므로 클라이언트가 유저의 라이프사이클을 테스트하는 데에는 문제가 없을 것 같아 기존 테스트 API는 deprecated 처리했습니다.