### PR TITLE
통계 관련 API 내 통계처리 로직 수정

### DIFF
--- a/src/main/java/com/nexters/keyme/domain/question/domain/repository/QuestionSolvedRepository.java
+++ b/src/main/java/com/nexters/keyme/domain/question/domain/repository/QuestionSolvedRepository.java
@@ -21,10 +21,10 @@ public interface QuestionSolvedRepository extends JpaRepository<QuestionSolved, 
     List<QuestionSolved> findAllByTestResultIdWithQuestion(Long resultId);
 
     @Query(
-        "select new com.nexters.keyme.domain.question.dto.internal.QuestionStatisticInfo(qs.question.questionId, qs.question.title, qs.question.keyword, qs.question.questionCategory, avg(qs.score)) " +
+        "select new com.nexters.keyme.domain.question.dto.internal.QuestionStatisticInfo(qs.question.questionId, qs.question.title, qs.question.keyword, qs.question.questionCategory, " +
+                "avg(CASE WHEN qs.testResult.solver.id != qs.owner.id or qs.testResult.solver.id IS NULL THEN qs.score END)) " +
             "from QuestionSolved qs " +
             "where qs.testResult.test.testId = :testId " +
-                "and (qs.testResult.solver.id != qs.owner.id or qs.testResult.solver.id IS NULL) " +
             "group by qs.question.questionId "
     )
     List<QuestionStatisticInfo> findAllAssociatedQuestionStatisticsByTestId(Long testId);

--- a/src/main/java/com/nexters/keyme/domain/test/application/TestServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/test/application/TestServiceImpl.java
@@ -107,12 +107,12 @@ public class TestServiceImpl implements TestService {
     @Transactional(readOnly = true)
     @Override
     public SingleTestStatisticsResponse getTestStatistics(Long memberId, Long testId) {
-        testRepository.findById(testId)
+        Long testOwnerId = testRepository.findById(testId)
                 .map(test -> test.getMember().getId())
-                .filter(testOwnerId -> testOwnerId.equals(memberId))
+                .filter(ownerId -> ownerId.equals(memberId))
                 .orElseThrow(NotFoundTestException::new);
 
-        TestResultStatisticInfo testResultStatisticInfo = testResultRepository.findStatisticsByTestId(testId);
+        TestResultStatisticInfo testResultStatisticInfo = testResultRepository.findStatisticsByTestId(testId, testOwnerId);
         List<QuestionStatisticInfo> questionStatisticInfoList = questionSolvedRepository.findAllAssociatedQuestionStatisticsByTestId(testId);
 
         return new SingleTestStatisticsResponse(

--- a/src/main/java/com/nexters/keyme/domain/test/domain/repository/TestResultRepository.java
+++ b/src/main/java/com/nexters/keyme/domain/test/domain/repository/TestResultRepository.java
@@ -14,7 +14,8 @@ public interface TestResultRepository extends JpaRepository<TestResult, Long> {
 
     @Query(
         "select new com.nexters.keyme.domain.test.dto.internal.TestResultStatisticInfo(avg(tr.matchRate), COUNT(*)) from TestResult tr " +
-            "where tr.test.testId = :testId"
+            "where tr.test.testId = :testId " +
+                "and (tr.solver.id != :testOwnerId or tr.solver.id is null)"
     )
-    TestResultStatisticInfo findStatisticsByTestId(Long testId);
+    TestResultStatisticInfo findStatisticsByTestId(Long testId, Long testOwnerId);
 }


### PR DESCRIPTION
### Issue
- close #159 
- close #158 

### Summary
- Test 통계 내 Owner의 점수는 제외하였습니다.
- Question 통계 관련 API 호출시 Question 정보는 필수로 들어가도록 수정하였습니다.

### Description