### PR TITLE
TestResult 제출 시 Statistic 미동작 문제 해결

### DIFF
--- a/src/main/java/com/nexters/keyme/domain/question/dto/response/QuestionStatisticResponse.java
+++ b/src/main/java/com/nexters/keyme/domain/question/dto/response/QuestionStatisticResponse.java
@@ -1,5 +1,6 @@
 package com.nexters.keyme.domain.question.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.nexters.keyme.domain.question.dto.internal.QuestionStatisticInfo;
 import com.nexters.keyme.domain.question.domain.model.Question;
 import io.swagger.annotations.ApiModel;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class QuestionStatisticResponse extends QuestionResponse {
     private Double avgScore;
 

--- a/src/main/java/com/nexters/keyme/global/common/event/handler/GlobalEventHandler.java
+++ b/src/main/java/com/nexters/keyme/global/common/event/handler/GlobalEventHandler.java
@@ -15,6 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 @RequiredArgsConstructor
 @Component
@@ -26,7 +30,8 @@ public class GlobalEventHandler {
     private final TestResultValidator testResultValidator;
 
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleAddStatisticEvent(AddStatisticEvent event) {
         TestResult testResult = testResultValidator.validateTestResult(event.getResultId());
 
@@ -35,7 +40,6 @@ public class GlobalEventHandler {
             ScoreInfo info = new ScoreInfo(event.getTestOwnerId(), event.getSolverId(), question.getQuestionId(), questionSolved.getScore());
             statisticService.addNewScores(info);
         }
-
     }
 
     @EventListener


### PR DESCRIPTION
### Issue
- close #161 
- close #162 

### Summary
- PR #156  
  - 해당 PR merge 이후 TestResult 제출 시 Statistics가 저장되지 않는 문제 해결
- 추가적으로 QuestionStatistics 응답시 null인 필드는 응답JSON에서 제외

### Description
TestResult 제출(save) 시에 eventListener로 testResultId를 넘긴 후 handler에서 해당 id로 TestResult를 호출하는 과정에서 NotFoundTestResult 예외가 발생하였습니다.

**문제**
- TestResult 제출 트랜잭션이 commit 되지 않은 시점에서 다른 쓰레드(@ Async로 실행되는 EventListener handler)에서 TestResult를 find함. DB에는 testResult가 영구적으로 commit 되지 않았으므로 id로 testResult를 가져오지 못함. 또한 쓰레드도 다르므로 영속성 컨텍스트에서도 가져오지 못함.

**해결**
- EventListener를 TransactionalEventListener로 변경. commit 이후에 Event가 처리되도록 수정함.
- TransactionalEventListener 내에서는 새로운 커밋(insert, update, delete)을 할 수 없음. 따라서 트랜잭션 전파레벨도 REQUIRES_NEW 로 변경
- [참고 링크](https://wildeveloperetrain.tistory.com/246)