### PR TITLE
KeymeUnauthorizedException 시큐리티 필터에서 핸들링하도록 개선

### DIFF
--- a/src/main/java/com/nexters/keyme/global/security/filter/AuthenticationExceptionFilter.java
+++ b/src/main/java/com/nexters/keyme/global/security/filter/AuthenticationExceptionFilter.java
@@ -2,7 +2,9 @@ package com.nexters.keyme.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.keyme.global.common.dto.response.CommonResponse;
+import com.nexters.keyme.global.common.exceptions.KeymeUnauthorizedException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -15,6 +17,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RequiredArgsConstructor
+@Slf4j
 public class AuthenticationExceptionFilter extends OncePerRequestFilter {
 
     private final ObjectMapper objectMapper;
@@ -23,9 +26,10 @@ public class AuthenticationExceptionFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (AuthenticationException e) {
+        } catch (AuthenticationException | KeymeUnauthorizedException e) {
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
+            log.warn(e.getMessage());
             objectMapper.writeValue(response.getWriter(), new CommonResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
         }
     }


### PR DESCRIPTION
### Issue
- close #167

### Summary
JWT 검증 과정에서 발생하는 KeymeUnauthorizedException을 핸들링하는 시큐리티 필터 코드를 개선했습니다.

### Description
- JWT 인증 과정에서 JWT 관련 예외들을 `KeymeUnauthorizedException`으로 변환해서 던지는데, 이를 커스텀 시큐리티 필터인 `AuthenticationExceptionFilter`에서 잡지 않아 생긴 문제입니다.
- `AuthenticationExceptionFilter`에서 `doFilter()` 이후 발생하는 KeymeUnauthorizedException 예외를 잡아 응답값에 예외 메시지를 출력하도록 하고, 예외 메시지를 warn 레벨로 로깅 처리했습니다.
- JWT 검증 과정에서 발생하면 (인가가 아닌) 인증이 실패한 것이니 Unauthorized보다는 Unauthenticated라는 생각도 드는데, 프로젝트 전반에서 혼용되고 있는 것 같아요. 다음 회의 때 잠깐 얘기해 보아도 좋을 것 같습니다.