### PR TITLE
멤버 통계 점수 추가 시 락 로직 변경

### DIFF
--- a/src/main/java/com/nexters/keyme/domain/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/statistics/application/StatisticServiceImpl.java
@@ -48,13 +48,16 @@ public class StatisticServiceImpl implements StatisticService {
     @Override
     public void addNewScores(ScoreInfo scoreInfo) {
         // FIXME - 내부에서만 사용중 domain service로 뺄것
-        Statistic statistic = statisticRepository.findByOwnerIdAndQuestionIdWithLock(scoreInfo.getOwnerId(), scoreInfo.getQuestionId())
+        Statistic statistic = statisticRepository.findByOwnerIdAndQuestionId(scoreInfo.getOwnerId(), scoreInfo.getQuestionId())
                 .orElseGet(() -> {
                     StatisticInfo info = new StatisticInfo(scoreInfo.getOwnerId(), scoreInfo.getQuestionId(), scoreInfo.getScore());
                     return createStatistic(info);
                 });
 
-        statistic.addNewScore(scoreInfo.getSolverId(), scoreInfo.getScore());
+        Statistic statisticWithLock = statisticRepository.findByIdWithLock(statistic.getId())
+                        .orElseThrow(NotFoundStatisticsException::new);
+
+        statisticWithLock.addNewScore(scoreInfo.getSolverId(), scoreInfo.getScore());
     }
 
     @Transactional

--- a/src/main/java/com/nexters/keyme/domain/statistics/application/StatisticServiceImpl.java
+++ b/src/main/java/com/nexters/keyme/domain/statistics/application/StatisticServiceImpl.java
@@ -47,7 +47,6 @@ public class StatisticServiceImpl implements StatisticService {
     @Transactional
     @Override
     public void addNewScores(ScoreInfo scoreInfo) {
-        // FIXME - 내부에서만 사용중 domain service로 뺄것
         Statistic statistic = statisticRepository.findByOwnerIdAndQuestionId(scoreInfo.getOwnerId(), scoreInfo.getQuestionId())
                 .orElseGet(() -> {
                     StatisticInfo info = new StatisticInfo(scoreInfo.getOwnerId(), scoreInfo.getQuestionId(), scoreInfo.getScore());
@@ -76,9 +75,12 @@ public class StatisticServiceImpl implements StatisticService {
         }
 
         statistics.sort(getStatisticComparator());
-
         List<CoordinateInfo> coordinates = conversionService.convertFrom(statistics);
+        List<StatisticResultResponse> results = createStatisticResultResponse(statistics, coordinates);
+        return new MemberStatisticResponse(memberId, results);
+    }
 
+    private List<StatisticResultResponse> createStatisticResultResponse(List<Statistic> statistics, List<CoordinateInfo> coordinates) {
         List<StatisticResultResponse> results = new ArrayList<>();
 
         for (int i = 0; i < statistics.size(); i++) {
@@ -90,8 +92,7 @@ public class StatisticServiceImpl implements StatisticService {
 
             results.add(new StatisticResultResponse(new StatisticQuestionResponse(question, statistic.getOwnerScore(), statistic.getSolverAvgScore()), new CoordinateResponse(coordinateInfo)));
         }
-
-        return new MemberStatisticResponse(memberId, results);
+        return results;
     }
 
     private static Comparator<Statistic> getStatisticComparator() {

--- a/src/main/java/com/nexters/keyme/domain/statistics/domain/repository/StatisticRepository.java
+++ b/src/main/java/com/nexters/keyme/domain/statistics/domain/repository/StatisticRepository.java
@@ -2,19 +2,16 @@ package com.nexters.keyme.domain.statistics.domain.repository;
 
 import com.nexters.keyme.domain.statistics.domain.model.Statistic;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import javax.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 
 public interface StatisticRepository extends JpaRepository<Statistic, Long> {
 
-    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT st FROM Statistic st WHERE st.ownerId = :ownerId AND st.questionId = :questionId")
-    Optional<Statistic> findByOwnerIdAndQuestionIdWithLock(@Param(value = "ownerId") long ownerId, @Param(value = "questionId") long questionId);
+    Optional<Statistic> findByOwnerIdAndQuestionId(@Param(value = "ownerId") long ownerId, @Param(value = "questionId") long questionId);
 
     @Query(value = "SELECT * FROM statistic st WHERE st.owner_id = :memberId AND solver_count > 0 ORDER BY st.match_rate LIMIT 5", nativeQuery = true)
     List<Statistic> findByMemberIdSortByMatchRateAsc(@Param(value = "memberId") long memberId);
@@ -27,5 +24,6 @@ public interface StatisticRepository extends JpaRepository<Statistic, Long> {
                                                 @Param(value = "cursor") long cursor,
                                                 @Param(value = "cursorScore") double cursorScore,
                                                 @Param(value = "limit") int limit);
-
+    @Query("SELECT st FROM Statistic st WHERE st.id = :id")
+    Optional<Statistic> findByIdWithLock(@Param(value = "id") long id);
 }

--- a/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
+++ b/src/test/java/com/nexters/keyme/statistics/domain/repository/StatisticRepositoryTest.java
@@ -20,7 +20,7 @@ class StatisticRepositoryTest {
     @Test
     @DisplayName("통계 정보 가져오기 테스트")
     void findByOwnerIdAndQuestionIdWithLock() {
-        Statistic statistic = statisticRepository.findByOwnerIdAndQuestionIdWithLock(1, 2)
+        Statistic statistic = statisticRepository.findByOwnerIdAndQuestionId(1, 2)
                 .orElseThrow(NotFoundStatisticsException::new);
 
         assertThat(statistic.getQuestionId()).isEqualTo(2L);


### PR DESCRIPTION
### Issue
- close #115 

### Summary
- 멤버 통계 점수 추가 시 PK로 탐색하는 메서드에만 락을 적용하도록 변경했습니다.

### Description
- 기존에 `ownerId`, `questionId` 조건으로 찾는 메서드에 비관적 락을 걸어 Next Key Lock을 걸면서 데드락이 생기는 것이라고 판단했는데, 현재 문제 상황이 간헐적으로만 발생하고 있어서 재현이 쉽지 않은 상황입니다.
- 우선은 추정대로 ownerId와 questionId를 조건으로 가져온 statistic 레코드에 다시 PK 조건으로 비관적 락을 걸어 처리하는 방식으로 개선했습니다. DB 요청을 두 번 보낸다는 단점이 있는데, 추후 레디스 등을 사용하게 된다면 분산 락 등의 형태로 개선할 수 있을 듯합니다.
- 로깅 등을 조금 더 보강해서 만약 추후 에러 재발 시 원인 파악을 조금 더 수월하게 하기 위한 방법을 고민해 보겠습니다!